### PR TITLE
KAIZEN-0: Håndterer wrappet ..PersonIkkeFunnet-exception fra Arena

### DIFF
--- a/src/main/java/no/nav/fo/veilarboppfolging/services/ArenaOppfolgingService.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/services/ArenaOppfolgingService.java
@@ -70,7 +70,9 @@ public class ArenaOppfolgingService {
             return ArenaOppfolgingMapper.mapTilArenaOppfolgingsstatusV2(hentOppfoelgingsstatusResponse);
         } catch (java.lang.reflect.UndeclaredThrowableException e) {
             Throwable undeclared = e.getUndeclaredThrowable();
-            throw (undeclared != null  && undeclared.getCause() instanceof HentOppfoelgingsstatusPersonIkkeFunnet ? notFound(identifikator, undeclared.getCause()) : e);
+            throw undeclared != null  && undeclared.getCause() instanceof HentOppfoelgingsstatusPersonIkkeFunnet 
+                    ? notFound(identifikator, undeclared.getCause()) 
+                    : e;
         } catch (HentOppfoelgingsstatusPersonIkkeFunnet e) {
             throw notFound(identifikator, e);
         } catch (HentOppfoelgingsstatusSikkerhetsbegrensning e) {


### PR DESCRIPTION
**TL;DR:** Denne PR-en medfører at vi ikke lenger logger WARN fra OppfolgingResolver dersom personen vi slår opp ikke finnes i Arena. Samtidig vil rest-operasjonene `/person/{fnr}/oppfolgingsstatus` og `/person/{fnr}/oppfoelgingsstatus` nå returnere 404 i stedet for 500 ved oppslag på personer som ikke finnes.

PersonIkkeFunnet i Arena er helt vanlig og ikke noe vi ønsker å logge som feil. Håndtering av denne situasjonen har ikke fungert, siden den kommer wrappet i en `UndeclaredThrowableException` fra Soap-tjenesten.
Denne PR-en håndterer dette slik at oppførsel blir lik enten exception fra Arena kommer wrappet eller ikke.