### PR TITLE
KAIZEN-0 query param for oppfolgingsstatus for å gå mot arena direkte

### DIFF
--- a/src/main/java/no/nav/fo/veilarboppfolging/rest/ArenaOppfolgingRessurs.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/rest/ArenaOppfolgingRessurs.java
@@ -2,6 +2,7 @@ package no.nav.fo.veilarboppfolging.rest;
 
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiParam;
 import io.vavr.control.Try;
 import no.nav.apiapp.security.PepClient;
 import no.nav.dialogarena.aktor.AktorService;
@@ -17,11 +18,7 @@ import no.nav.sbl.featuretoggle.unleash.UnleashService;
 
 import org.springframework.stereotype.Component;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -106,11 +103,14 @@ public class ArenaOppfolgingRessurs {
      */
     @GET
     @Path("/oppfolgingsstatus")
-    public OppfolgingEnhetMedVeileder getOppfolginsstatus(@PathParam("fnr") String fnr) throws PepException {
+    public OppfolgingEnhetMedVeileder getOppfolginsstatus(@PathParam("fnr") String fnr,
+                                                          @ApiParam(value = "Deprecated og bør ikke settes. " +
+                                                                            "Tilgjengelig pga. overgang til veilarbarena som har litt forsinkelse på data i Arena i motsetning til SOAP tjeneste.")
+                                                          @QueryParam("brukArena") boolean brukArena) throws PepException {
         pepClient.sjekkLeseTilgangTilFnr(fnr);
 
         OppfolgingEnhetMedVeileder res;
-        if(unleash.isEnabled("veilarboppfolging.oppfolgingsstatus.fra.veilarbarena")) {
+        if(!brukArena && unleash.isEnabled("veilarboppfolging.oppfolgingsstatus.fra.veilarbarena")) {
             ArenaBruker arenaBruker = oppfolgingsbrukerService.hentOppfolgingsbruker(fnr).orElseThrow(() -> new NotFoundException("Bruker ikke funnet"));
             res = new OppfolgingEnhetMedVeileder()
                     .setServicegruppe(arenaBruker.getKvalifiseringsgruppekode())


### PR DESCRIPTION
Vi ønsker å gå over til å bruke veilarbarena, men det kan ha konsekvenser for konsumenter av endepunktet da det vil føre til en forsinkelse på data i Arena. Dette må tas høyde for av konsumenter før nytt query param kan tas bort igjen.