### PR TITLE
Feature/utvider hent oppfolgings status med rettighetsgruppe

### DIFF
--- a/src/main/java/no/nav/fo/veilarboppfolging/domain/OppfolgingStatusData.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/domain/OppfolgingStatusData.java
@@ -30,6 +30,7 @@ public class OppfolgingStatusData {
     public Boolean erSykmeldtMedArbeidsgiver;
     public String servicegruppe;
     public String formidlingsgruppe;
+    public String rettighetsgruppe;
 
     @Deprecated
     public Boolean erIkkeArbeidssokerUtenOppfolging;

--- a/src/main/java/no/nav/fo/veilarboppfolging/mappers/VeilarbArenaOppfolging.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/mappers/VeilarbArenaOppfolging.java
@@ -12,6 +12,7 @@ public class VeilarbArenaOppfolging {
     public String fodselsnr;
     public String formidlingsgruppekode;
     public String kvalifiseringsgruppekode;
+    public String rettighetsgruppekode;
     public ZonedDateTime iserv_fra_dato;
     public String hovedmaalkode;
     public String nav_kontor;

--- a/src/main/java/no/nav/fo/veilarboppfolging/rest/ArenaOppfolgingRessurs.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/rest/ArenaOppfolgingRessurs.java
@@ -126,6 +126,7 @@ public class ArenaOppfolgingRessurs {
             res = new OppfolgingEnhetMedVeileder()
                     .setServicegruppe(veilarbArenaOppfolging.getKvalifiseringsgruppekode())
                     .setFormidlingsgruppe(veilarbArenaOppfolging.getFormidlingsgruppekode())
+                    .setRettighetsgruppe(veilarbArenaOppfolging.getRettighetsgruppekode())
                     .setOppfolgingsenhet(hentEnhet(veilarbArenaOppfolging.getNav_kontor()))
                     .setHovedmaalkode(veilarbArenaOppfolging.getHovedmaalkode());
 
@@ -133,10 +134,11 @@ public class ArenaOppfolgingRessurs {
             no.nav.fo.veilarboppfolging.domain.ArenaOppfolging arenaData = arenaOppfolgingService.hentArenaOppfolging(fnr);
             Optional<VeilarbArenaOppfolging> oppfolgingsbrukerStatus = oppfolgingsbrukerService.hentOppfolgingsbruker(fnr);
             res = new OppfolgingEnhetMedVeileder()
-                .setServicegruppe(arenaData.getServicegruppe())
-                .setFormidlingsgruppe(arenaData.getFormidlingsgruppe())
-                .setOppfolgingsenhet(hentEnhet(arenaData.getOppfolgingsenhet()))
-                .setHovedmaalkode(oppfolgingsbrukerStatus.map(VeilarbArenaOppfolging::getHovedmaalkode).orElse(null));
+                    .setServicegruppe(arenaData.getServicegruppe())
+                    .setFormidlingsgruppe(arenaData.getFormidlingsgruppe())
+                    .setRettighetsgruppe(arenaData.getRettighetsgruppe())
+                    .setOppfolgingsenhet(hentEnhet(arenaData.getOppfolgingsenhet()))
+                    .setHovedmaalkode(oppfolgingsbrukerStatus.map(VeilarbArenaOppfolging::getHovedmaalkode).orElse(null));
         }
 
         if (AutorisasjonService.erInternBruker()) {

--- a/src/main/java/no/nav/fo/veilarboppfolging/rest/OppfolgingRessurs.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/rest/OppfolgingRessurs.java
@@ -243,7 +243,8 @@ public class OppfolgingRessurs implements OppfolgingController, VeilederOppfolgi
                 .setErSykmeldtMedArbeidsgiver(oppfolgingStatusData.getErSykmeldtMedArbeidsgiver())
                 .setHarSkriveTilgang(true)
                 .setServicegruppe(oppfolgingStatusData.getServicegruppe())
-                .setFormidlingsgruppe(oppfolgingStatusData.getFormidlingsgruppe());
+                .setFormidlingsgruppe(oppfolgingStatusData.getFormidlingsgruppe())
+                .setRettighetsgruppe(oppfolgingStatusData.getRettighetsgruppe());
 
 
         if (AutorisasjonService.erInternBruker()) {

--- a/src/main/java/no/nav/fo/veilarboppfolging/rest/domain/OppfolgingEnhetMedVeileder.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/rest/domain/OppfolgingEnhetMedVeileder.java
@@ -10,6 +10,7 @@ public class OppfolgingEnhetMedVeileder {
     private Oppfolgingsenhet oppfolgingsenhet;
     private String veilederId;
     private String formidlingsgruppe;
+    private String rettighetsgruppe;
     private String servicegruppe;
     private String hovedmaalkode;
 }

--- a/src/main/java/no/nav/fo/veilarboppfolging/rest/domain/OppfolgingStatus.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/rest/domain/OppfolgingStatus.java
@@ -30,6 +30,7 @@ public class OppfolgingStatus {
     private Boolean erSykmeldtMedArbeidsgiver;
     private String servicegruppe;
     private String formidlingsgruppe;
+    private String rettighetsgruppe;
 
     @Deprecated
     private Boolean erIkkeArbeidssokerUtenOppfolging;

--- a/src/main/java/no/nav/fo/veilarboppfolging/services/OppfolgingResolver.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/services/OppfolgingResolver.java
@@ -354,6 +354,10 @@ public class OppfolgingResolver {
         return arenaOppfolgingTilstand().map(ArenaOppfolgingTilstand::getFormidlingsgruppe).orElse(null);
     }
 
+    String getRettighetsgruppe() {
+        return arenaOppfolgingTilstand().map(ArenaOppfolgingTilstand::getRettighetsgruppe).orElse(null);
+    }
+
     private Date getInaktiveringsDato(ArenaOppfolgingTilstand status) {
         return Optional.ofNullable(status.getInaktiveringsdato()).isPresent()
                 ? Date.from(status.getInaktiveringsdato().atStartOfDay().atZone(ZoneId.systemDefault()).toInstant())
@@ -647,6 +651,7 @@ public class OppfolgingResolver {
 class ArenaOppfolgingTilstand {
     String formidlingsgruppe;
     String servicegruppe;
+    String rettighetsgruppe;
     String oppfolgingsenhet;
     LocalDate inaktiveringsdato;
 
@@ -654,6 +659,7 @@ class ArenaOppfolgingTilstand {
         return new ArenaOppfolgingTilstand(
                 arenaOppfolging.getFormidlingsgruppe(),
                 arenaOppfolging.getServicegruppe(),
+                arenaOppfolging.getRettighetsgruppe(),
                 arenaOppfolging.getOppfolgingsenhet(),
                 arenaOppfolging.getInaktiveringsdato());
     }
@@ -662,6 +668,7 @@ class ArenaOppfolgingTilstand {
         return new ArenaOppfolgingTilstand(
                 veilarbArenaOppfolging.getFormidlingsgruppekode(),
                 veilarbArenaOppfolging.getKvalifiseringsgruppekode(),
+                veilarbArenaOppfolging.getRettighetsgruppekode(),
                 veilarbArenaOppfolging.getNav_kontor(),
                 Optional.ofNullable(veilarbArenaOppfolging.getIserv_fra_dato()).map(ZonedDateTime::toLocalDate).orElse(null)
         );

--- a/src/main/java/no/nav/fo/veilarboppfolging/services/OppfolgingService.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/services/OppfolgingService.java
@@ -237,6 +237,7 @@ public class OppfolgingService {
                 .setInaktiveringsdato(oppfolgingResolver.getInaktiveringsDato())
                 .setServicegruppe(oppfolgingResolver.getServicegruppe())
                 .setFormidlingsgruppe(oppfolgingResolver.getFormidlingsgruppe())
+                .setRettighetsgruppe(oppfolgingResolver.getRettighetsgruppe())
                 .setKanVarsles(!manuell && dkifResponse.isKanVarsles());
     }
 


### PR DESCRIPTION
Ifm. at vi I veilarbregistrering ønsker å kunne filtrere på retrtighetsgruppe (f.eks. AAP), ønsker vi å utvide veilarboppfolging til å eksponere denne informasjonen i en tjeneste vi allerede bruker fra før.

Ut fra hva jeg greier å se, blir informasjonen allerede hentet i dag, men ikke mappet opp i vårt tilfelle. Har derfor forsøkt å utvide mappingen, slik at det nå blir gjort tilgjengelig.