### PR TITLE
[KAIZEN-0] Utvider OppfolgingStatus med rettighetsgruppe

### DIFF
--- a/src/main/java/no/nav/fo/veilarboppfolging/domain/OppfolgingStatusData.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/domain/OppfolgingStatusData.java
@@ -30,6 +30,7 @@ public class OppfolgingStatusData {
     public Boolean erSykmeldtMedArbeidsgiver;
     public String servicegruppe;
     public String formidlingsgruppe;
+    public String rettighetsgruppe;
 
     @Deprecated
     public Boolean erIkkeArbeidssokerUtenOppfolging;

--- a/src/main/java/no/nav/fo/veilarboppfolging/mappers/VeilarbArenaOppfolging.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/mappers/VeilarbArenaOppfolging.java
@@ -12,6 +12,7 @@ public class VeilarbArenaOppfolging {
     public String fodselsnr;
     public String formidlingsgruppekode;
     public String kvalifiseringsgruppekode;
+    public String rettighetsgruppekode;
     public ZonedDateTime iserv_fra_dato;
     public String hovedmaalkode;
     public String nav_kontor;

--- a/src/main/java/no/nav/fo/veilarboppfolging/rest/OppfolgingRessurs.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/rest/OppfolgingRessurs.java
@@ -8,8 +8,23 @@ import no.nav.fo.veilarboppfolging.domain.*;
 import no.nav.fo.veilarboppfolging.rest.api.OppfolgingController;
 import no.nav.fo.veilarboppfolging.rest.api.SystemOppfolgingController;
 import no.nav.fo.veilarboppfolging.rest.api.VeilederOppfolgingController;
-import no.nav.fo.veilarboppfolging.rest.domain.*;
-import no.nav.fo.veilarboppfolging.services.*;
+import no.nav.fo.veilarboppfolging.rest.domain.AvslutningStatus;
+import no.nav.fo.veilarboppfolging.rest.domain.Bruker;
+import no.nav.fo.veilarboppfolging.rest.domain.Eskaleringsvarsel;
+import no.nav.fo.veilarboppfolging.rest.domain.KvpPeriodeDTO;
+import no.nav.fo.veilarboppfolging.rest.domain.Mal;
+import no.nav.fo.veilarboppfolging.rest.domain.OppfolgingPeriodeDTO;
+import no.nav.fo.veilarboppfolging.rest.domain.OppfolgingStatus;
+import no.nav.fo.veilarboppfolging.rest.domain.StartEskaleringDTO;
+import no.nav.fo.veilarboppfolging.rest.domain.StartKvpDTO;
+import no.nav.fo.veilarboppfolging.rest.domain.StoppEskaleringDTO;
+import no.nav.fo.veilarboppfolging.rest.domain.StoppKvpDTO;
+import no.nav.fo.veilarboppfolging.rest.domain.VeilederBegrunnelseDTO;
+import no.nav.fo.veilarboppfolging.services.AktiverBrukerService;
+import no.nav.fo.veilarboppfolging.services.HistorikkService;
+import no.nav.fo.veilarboppfolging.services.KvpService;
+import no.nav.fo.veilarboppfolging.services.MalService;
+import no.nav.fo.veilarboppfolging.services.OppfolgingService;
 import no.nav.sbl.dialogarena.common.abac.pep.exception.PepException;
 import org.springframework.stereotype.Component;
 
@@ -243,7 +258,8 @@ public class OppfolgingRessurs implements OppfolgingController, VeilederOppfolgi
                 .setErSykmeldtMedArbeidsgiver(oppfolgingStatusData.getErSykmeldtMedArbeidsgiver())
                 .setHarSkriveTilgang(true)
                 .setServicegruppe(oppfolgingStatusData.getServicegruppe())
-                .setFormidlingsgruppe(oppfolgingStatusData.getFormidlingsgruppe());
+                .setFormidlingsgruppe(oppfolgingStatusData.getFormidlingsgruppe())
+                .setRettighetsgruppe(oppfolgingStatusData.getRettighetsgruppe());
 
 
         if (AutorisasjonService.erInternBruker()) {

--- a/src/main/java/no/nav/fo/veilarboppfolging/rest/domain/OppfolgingStatus.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/rest/domain/OppfolgingStatus.java
@@ -30,6 +30,7 @@ public class OppfolgingStatus {
     private Boolean erSykmeldtMedArbeidsgiver;
     private String servicegruppe;
     private String formidlingsgruppe;
+    private String rettighetsgruppe;
 
     @Deprecated
     private Boolean erIkkeArbeidssokerUtenOppfolging;

--- a/src/main/java/no/nav/fo/veilarboppfolging/services/OppfolgingService.java
+++ b/src/main/java/no/nav/fo/veilarboppfolging/services/OppfolgingService.java
@@ -237,6 +237,7 @@ public class OppfolgingService {
                 .setInaktiveringsdato(oppfolgingResolver.getInaktiveringsDato())
                 .setServicegruppe(oppfolgingResolver.getServicegruppe())
                 .setFormidlingsgruppe(oppfolgingResolver.getFormidlingsgruppe())
+                .setRettighetsgruppe(oppfolgingResolver.getRettighetsgruppe())
                 .setKanVarsles(!manuell && dkifResponse.isKanVarsles());
     }
 


### PR DESCRIPTION
I veilarbregistrering har vi behov for rettighetsgruppe for å kunne styre brukerflyt ut fra om bruker har AAP eller tilsvarende.
Har valgt å utvide eksisterende endepunkt /oppfolging og responsen `OppfolgingStatus` med rettighetsgruppe. Informasjonen populeres nå fra både Arena direkte og Arena via veilarbarena.
Har ikke valgt å eksponere rettighetsgruppe via ArenaOppfolgingRessurs, da vi ikke ønsker å eksponere det til flere enn nødvendig.