### PR TITLE
KAIZEN-0 Fikset bug for å hente ut 'harSkrivetilgangTilBruker'

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
@@ -77,8 +77,8 @@ public class AuthService {
         return IdentType.EksternBruker.equals(identType);
     }
 
-    public boolean harTilgangTilEnhet(String enhetId) {
-        return veilarbPep.harVeilederTilgangTilEnhet(getInnloggetBrukerIdent(), enhetId);
+    public boolean harVeilederTilgangTilEnhet(String enhetId) {
+        return veilarbPep.harVeilederTilgangTilEnhet(getInnloggetVeilederIdent(), enhetId);
     }
 
     public boolean harVeilederSkriveTilgangTilFnr(String veilederId, String fnr) {
@@ -107,7 +107,7 @@ public class AuthService {
     }
 
     public void sjekkTilgangTilEnhet(String enhetId) {
-        if (!harTilgangTilEnhet(enhetId)) {
+        if (!harVeilederTilgangTilEnhet(enhetId)) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
     }

--- a/src/main/java/no/nav/veilarboppfolging/service/HistorikkService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/HistorikkService.java
@@ -67,7 +67,7 @@ public class HistorikkService {
 
     @SneakyThrows
     private boolean harTilgangTilEnhet(Kvp kvp) {
-        return authService.harTilgangTilEnhet(kvp.getEnhet());
+        return authService.harVeilederTilgangTilEnhet(kvp.getEnhet());
     }
 
     private InnstillingsHistorikk tilDTO(VeilederTilordningerData veilederTilordningerData) {

--- a/src/main/java/no/nav/veilarboppfolging/service/KvpService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/KvpService.java
@@ -70,7 +70,7 @@ public class KvpService {
         }
 
         String enhet = oppfolgingClient.finnEnhetId(fnr);
-        if (!authService.harTilgangTilEnhet(enhet)) {
+        if (!authService.harVeilederTilgangTilEnhet(enhet)) {
             log.warn(format("Ingen tilgang til enhet '%s'", enhet));
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
@@ -96,7 +96,7 @@ public class KvpService {
 
         authService.sjekkLesetilgangMedAktorId(aktorId);
 
-        if (!authService.harTilgangTilEnhet(oppfolgingClient.finnEnhetId(fnr))) {
+        if (!authService.harVeilederTilgangTilEnhet(oppfolgingClient.finnEnhetId(fnr))) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
 

--- a/src/main/java/no/nav/veilarboppfolging/service/MalService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/MalService.java
@@ -102,7 +102,7 @@ public class MalService {
     }
 
     private void sjekkEnhetTilgang(Kvp kvp) {
-        if (!authService.harTilgangTilEnhet(kvp.getEnhet())) {
+        if (!authService.harVeilederTilgangTilEnhet(kvp.getEnhet())) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
     }

--- a/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
@@ -179,7 +179,7 @@ public class OppfolgingService {
         authService.sjekkLesetilgangMedFnr(fnr);
         Optional<VeilarbArenaOppfolging> arenaBruker = arenaOppfolgingService.hentOppfolgingFraVeilarbarena(fnr);
         String oppfolgingsenhet = arenaBruker.map(VeilarbArenaOppfolging::getNav_kontor).orElse(null);
-        boolean tilgangTilEnhet = authService.harTilgangTilEnhet(oppfolgingsenhet);
+        boolean tilgangTilEnhet = authService.harVeilederTilgangTilEnhet(oppfolgingsenhet);
         return new VeilederTilgang().setTilgangTilBrukersKontor(tilgangTilEnhet);
     }
 
@@ -231,7 +231,9 @@ public class OppfolgingService {
                 .orElse(false);
 
         long kvpId = kvpRepository.gjeldendeKvp(aktorId);
-        boolean harSkrivetilgangTilBruker = !kvpService.erUnderKvp(kvpId) || authService.harTilgangTilEnhet(kvpRepository.fetch(kvpId).getEnhet());
+        boolean harSkrivetilgangTilBruker = (authService.erEksternBruker() && fnr.equals(authService.getInnloggetBrukerIdent()))
+                || !kvpService.erUnderKvp(kvpId)
+                || authService.harVeilederTilgangTilEnhet(kvpRepository.fetch(kvpId).getEnhet());
 
         Boolean erInaktivIArena = maybeArenaOppfolging.map(ao -> erIserv(ao.getFormidlingsgruppe())).orElse(null);
 
@@ -323,7 +325,7 @@ public class OppfolgingService {
         Kvp kvp = null;
         if (t.getGjeldendeKvpId() != 0) {
             kvp = kvpRepository.fetch(t.getGjeldendeKvpId());
-            if (authService.harTilgangTilEnhet(kvp.getEnhet())) {
+            if (authService.harVeilederTilgangTilEnhet(kvp.getEnhet())) {
                 o.setGjeldendeKvp(kvp);
             }
         }
@@ -393,7 +395,7 @@ public class OppfolgingService {
     }
 
     private boolean erKvpIPeriode(Kvp kvp, Oppfolgingsperiode periode) {
-        return authService.harTilgangTilEnhet(kvp.getEnhet())
+        return authService.harVeilederTilgangTilEnhet(kvp.getEnhet())
                 && kvpEtterStartenAvPeriode(kvp, periode)
                 && kvpForSluttenAvPeriode(kvp, periode);
     }

--- a/src/main/java/no/nav/veilarboppfolging/utils/KvpUtils.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/KvpUtils.java
@@ -20,7 +20,7 @@ public class KvpUtils {
     public static boolean sjekkTilgangGittKvp(AuthService authService, List<Kvp> kvpList, Supplier<Date> dateSupplier) {
         for (Kvp kvp : kvpList) {
             if (between(kvp.getOpprettetDato(), kvp.getAvsluttetDato(), dateSupplier.get())) {
-                return authService.harTilgangTilEnhet(kvp.getEnhet());
+                return authService.harVeilederTilgangTilEnhet(kvp.getEnhet());
             }
         }
         return true;

--- a/src/test/java/no/nav/veilarboppfolging/service/HistorikkServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/HistorikkServiceTest.java
@@ -83,7 +83,7 @@ public class HistorikkServiceTest {
 
     @Test
     public void saksbehandler_har_ikke_tilgang_til_enhet() {
-        when(authService.harTilgangTilEnhet(ENHET)).thenReturn(false);
+        when(authService.harVeilederTilgangTilEnhet(ENHET)).thenReturn(false);
 
         List<InnstillingsHistorikk> historikk = historikkService.hentInstillingsHistorikk(FNR);
         List<String> begrunnelser = historikk.stream()
@@ -95,7 +95,7 @@ public class HistorikkServiceTest {
 
     @Test
     public void saksbehandler_har_tilgang_til_enhet() {
-        when(authService.harTilgangTilEnhet(ENHET)).thenReturn(true);
+        when(authService.harVeilederTilgangTilEnhet(ENHET)).thenReturn(true);
 
         List<InnstillingsHistorikk> historikk = historikkService.hentInstillingsHistorikk(FNR);
         List<String> begrunnelser = historikk.stream()

--- a/src/test/java/no/nav/veilarboppfolging/service/KvpServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/KvpServiceTest.java
@@ -63,7 +63,7 @@ public class KvpServiceTest {
         when(oppfolgingsStatusRepository.fetch(AKTOR_ID)).thenReturn(new OppfolgingTable().setUnderOppfolging(true));
         when(oppfolgingClient.finnEnhetId(FNR)).thenReturn(ENHET);
 
-        when(authService.harTilgangTilEnhet(anyString())).thenReturn(true);
+        when(authService.harVeilederTilgangTilEnhet(anyString())).thenReturn(true);
         when(authService.getAktorIdOrThrow(FNR)).thenReturn(AKTOR_ID);
         when(authService.getInnloggetVeilederIdent()).thenReturn(VEILEDER);
     }
@@ -118,7 +118,7 @@ public class KvpServiceTest {
         verify(authService, times(1)).sjekkLesetilgangMedAktorId(AKTOR_ID);
         verify(oppfolgingsStatusRepository, times(1)).fetch(AKTOR_ID);
         verify(kvpRepositoryMock, times(1)).stopKvp(eq(kvpId), eq(AKTOR_ID), eq(VEILEDER), eq(STOP_BEGRUNNELSE), eq(NAV));
-        verify(authService, times(1)).harTilgangTilEnhet(ENHET);
+        verify(authService, times(1)).harVeilederTilgangTilEnhet(ENHET);
     }
 
     @Test
@@ -145,7 +145,7 @@ public class KvpServiceTest {
 
     @Test
     public void startKvpInhenEnhetTilgang() {
-        when(authService.harTilgangTilEnhet(ENHET)).thenReturn(false);
+        when(authService.harVeilederTilgangTilEnhet(ENHET)).thenReturn(false);
 
         try {
             kvpService.startKvp(FNR, START_BEGRUNNELSE);
@@ -156,7 +156,7 @@ public class KvpServiceTest {
 
     @Test
     public void stopKvpInhenEnhetTilgang() {
-        when(authService.harTilgangTilEnhet(ENHET)).thenReturn(false);
+        when(authService.harVeilederTilgangTilEnhet(ENHET)).thenReturn(false);
 
         try {
             kvpService.stopKvp(FNR, STOP_BEGRUNNELSE);

--- a/src/test/java/no/nav/veilarboppfolging/service/MalServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/MalServiceTest.java
@@ -73,7 +73,7 @@ public class MalServiceTest {
     public void oppdater_mal_for_kvp_uten_tilgang() {
         when(kvpRepositoryMock.gjeldendeKvp(anyString())).thenReturn(KVP_ID);
         when(kvpRepositoryMock.fetch(anyLong())).thenReturn(aktivKvp());
-        when(authService.harTilgangTilEnhet(ENHET)).thenReturn(false);
+        when(authService.harVeilederTilgangTilEnhet(ENHET)).thenReturn(false);
 
         malService.oppdaterMal("mal", FNR, VEILEDER);
     }
@@ -104,7 +104,7 @@ public class MalServiceTest {
     public void hent_mal_opprettet_etter_kvp_veileder_har_ikke_tilgang() {
         when(kvpRepositoryMock.hentKvpHistorikk(AKTOR_ID)).thenReturn(kvpHistorikk());
         when(maalRepository.fetch(MAL_ID)).thenReturn(mal(from(IN_KVP)));
-        when(authService.harTilgangTilEnhet(ENHET)).thenReturn(false);
+        when(authService.harVeilederTilgangTilEnhet(ENHET)).thenReturn(false);
 
         MalData malData = malService.hentMal(FNR);
         assertThat(malData.getId()).isEqualTo(0L);
@@ -114,7 +114,7 @@ public class MalServiceTest {
     public void hent_mal_opprettet_etter_kvp_veileder_har_tilgang() {
         when(kvpRepositoryMock.hentKvpHistorikk(AKTOR_ID)).thenReturn(kvpHistorikk());
         when(maalRepository.fetch(MAL_ID)).thenReturn(mal(from(IN_KVP)));
-        when(authService.harTilgangTilEnhet(ENHET)).thenReturn(true);
+        when(authService.harVeilederTilgangTilEnhet(ENHET)).thenReturn(true);
 
         MalData malData = malService.hentMal(FNR);
         assertThat(malData.getId()).isEqualTo(MAL_ID);
@@ -123,7 +123,7 @@ public class MalServiceTest {
     @Test
     public void hent_mal_historikk_med_kvp_i_midten_veileder_har_Tilgang() {
         when(kvpRepositoryMock.hentKvpHistorikk(AKTOR_ID)).thenReturn(kvpHistorikk());
-        when(authService.harTilgangTilEnhet(ENHET)).thenReturn(true);
+        when(authService.harVeilederTilgangTilEnhet(ENHET)).thenReturn(true);
         when(maalRepository.aktorMal(AKTOR_ID)).thenReturn(malList());
 
         List<MalData> malData = malService.hentMalList(FNR);
@@ -134,7 +134,7 @@ public class MalServiceTest {
     @Test
     public void hent_mal_historikk_med_kvp_i_midten_veileder_har_ikke_Tilgang() {
         when(kvpRepositoryMock.hentKvpHistorikk(AKTOR_ID)).thenReturn(kvpHistorikk());
-        when(authService.harTilgangTilEnhet(ENHET)).thenReturn(false);
+        when(authService.harVeilederTilgangTilEnhet(ENHET)).thenReturn(false);
         when(maalRepository.aktorMal(AKTOR_ID)).thenReturn(malList());
 
         List<MalData> malData = malService.hentMalList(FNR);

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
@@ -115,21 +115,21 @@ public class OppfolgingServiceTest {
 
     @Test
     public void skal_publisere_paa_kafka_ved_oppdatering_av_manuell_status() {
-        when(authService.harTilgangTilEnhet(any())).thenReturn(true);
+        when(authService.harVeilederTilgangTilEnhet(any())).thenReturn(true);
 //        oppfolgingService.oppdaterManuellStatus(FNR, true, "test", SYSTEM, "test");
         verify(kafkaProducerService, times(1)).publiserEndringPaManuellStatus(AKTOR_ID, true);
     }
 
     @Test
     public void skal_publisere_paa_kafka_ved_start_paa_oppfolging() {
-        when(authService.harTilgangTilEnhet(any())).thenReturn(true);
+        when(authService.harVeilederTilgangTilEnhet(any())).thenReturn(true);
         oppfolgingService.startOppfolging(FNR);
         verify(kafkaProducerService, times(1)).publiserOppfolgingStartet(AKTOR_ID);
     }
 
     @Test
     public void skal_publisere_paa_kafka_ved_avsluttet_oppfolging() {
-        when(authService.harTilgangTilEnhet(any())).thenReturn(true);
+        when(authService.harVeilederTilgangTilEnhet(any())).thenReturn(true);
         oppfolgingService.avsluttOppfolging(FNR, VEILEDER, "");
         verify(kafkaProducerService, times(1)).publiserOppfolgingAvsluttet(AKTOR_ID);
     }
@@ -137,35 +137,35 @@ public class OppfolgingServiceTest {
     @Test(expected = ResponseStatusException.class)
     @SneakyThrows
     public void start_oppfolging_uten_enhet_tilgang() {
-        when(authService.harTilgangTilEnhet(any())).thenReturn(false);
+        when(authService.harVeilederTilgangTilEnhet(any())).thenReturn(false);
         oppfolgingService.startOppfolging(FNR);
     }
 
     @Test(expected = ResponseStatusException.class)
     @SneakyThrows
     public void avslutt_oppfolging_uten_enhet_tilgang() {
-        when(authService.harTilgangTilEnhet(any())).thenReturn(false);
+        when(authService.harVeilederTilgangTilEnhet(any())).thenReturn(false);
         oppfolgingService.avsluttOppfolging(FNR, VEILEDER, BEGRUNNELSE);
     }
 
     @Test(expected = ResponseStatusException.class)
     @SneakyThrows
     public void sett_manuell_uten_enhet_tilgang() {
-        when(authService.harTilgangTilEnhet(any())).thenReturn(false);
+        when(authService.harVeilederTilgangTilEnhet(any())).thenReturn(false);
 //        oppfolgingService.oppdaterManuellStatus(FNR, true, BEGRUNNELSE, NAV, VEILEDER);
     }
 
     @Test(expected = ResponseStatusException.class)
     @SneakyThrows
     public void settDigital_uten_enhet_tilgang() {
-        when(authService.harTilgangTilEnhet(any())).thenReturn(false);
+        when(authService.harVeilederTilgangTilEnhet(any())).thenReturn(false);
 //        oppfolgingService.settDigitalBruker(FNR);
     }
 
 
     @Test
     public void medEnhetTilgang() {
-        when(authService.harTilgangTilEnhet(any())).thenReturn(true);
+        when(authService.harVeilederTilgangTilEnhet(any())).thenReturn(true);
 
         gittEnhet(ENHET);
 
@@ -175,7 +175,7 @@ public class OppfolgingServiceTest {
 
     @Test
     public void utenEnhetTilgang() {
-        when(authService.harTilgangTilEnhet(any())).thenReturn(false);
+        when(authService.harVeilederTilgangTilEnhet(any())).thenReturn(false);
 
         gittEnhet(ENHET);
 

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest2.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest2.java
@@ -75,7 +75,7 @@ public class OppfolgingServiceTest2 extends IsolatedDatabaseTest {
 
     @Test
     public void oppfolging_periode_med_kvp_perioder() {
-        when(authService.harTilgangTilEnhet(ENHET)).thenReturn(true);
+        when(authService.harVeilederTilgangTilEnhet(ENHET)).thenReturn(true);
 
         gittOppfolgingForAktor(AKTOR_ID);
         gitt_kvp_periode(ENHET);
@@ -87,8 +87,8 @@ public class OppfolgingServiceTest2 extends IsolatedDatabaseTest {
 
     @Test
     public void oppfolging_periode_med_kvp_perioder_bare_tilgang_til_en() {
-        when(authService.harTilgangTilEnhet(ENHET)).thenReturn(true);
-        when(authService.harTilgangTilEnhet(OTHER_ENHET)).thenReturn(false);
+        when(authService.harVeilederTilgangTilEnhet(ENHET)).thenReturn(true);
+        when(authService.harVeilederTilgangTilEnhet(OTHER_ENHET)).thenReturn(false);
 
         gittOppfolgingForAktor(AKTOR_ID);
         gitt_kvp_periode(ENHET);


### PR DESCRIPTION
Uthenting av OppfolgingStatusData for eksterne brukere med KVP feilet siden det blir gjort en sjekk som krever at de er innlogget som en veileder. Fjernet sjekk på tilgang til enhet for eksterne brukere.