### PR TITLE
Fiks veiledertilordning query

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/repository/VeilederTilordningerRepository.java
+++ b/src/main/java/no/nav/veilarboppfolging/repository/VeilederTilordningerRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static no.nav.veilarboppfolging.repository.OppfolgingsStatusRepository.*;
+import static no.nav.veilarboppfolging.utils.DbUtils.queryForNullableObject;
 
 @Repository
 public class VeilederTilordningerRepository {
@@ -31,7 +32,7 @@ public class VeilederTilordningerRepository {
 
     public Optional<Tilordning> hentTilordnetVeileder(String aktorId) {
         String sql = format("SELECT * FROM %s WHERE %s = ?", TABLE_NAME, AKTOR_ID);
-        return Optional.ofNullable(db.queryForObject(sql, VeilederTilordningerRepository::map, aktorId));
+        return queryForNullableObject(db, sql, VeilederTilordningerRepository::map, aktorId);
     }
 
     public void upsertVeilederTilordning(String aktoerId, String veileder) {

--- a/src/main/java/no/nav/veilarboppfolging/utils/DbUtils.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/DbUtils.java
@@ -1,6 +1,8 @@
 package no.nav.veilarboppfolging.utils;
 
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -26,4 +28,11 @@ public class DbUtils {
                 .orElse(null);
     }
 
+    public static <T> Optional<T> queryForNullableObject(JdbcTemplate db, String sql, RowMapper<T> rowMapper, Object... args) {
+        try {
+            return Optional.ofNullable(db.queryForObject(sql, rowMapper, args));
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
 }


### PR DESCRIPTION
Skal støtte 0 eller 1 treff