### PR TITLE
Fikset bug hvor melding blir publisert på kafka uten at oppfølging blir startet

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
@@ -383,8 +383,16 @@ public class OppfolgingService {
         );
     }
 
-    @Transactional
     public void startOppfolgingHvisIkkeAlleredeStartet(Oppfolgingsbruker oppfolgingsbruker) {
+        startOppfolgingHvisIkkeAlleredeStartet(oppfolgingsbruker, true);
+    }
+
+    /**
+     * Det er veldig hacky å legge til et flagg for å kontrollere funksjonalitet, men slik som veilarboppfolging er i dag
+     * så er det ikke noen bedre alternativer for å håndtere async ting som skjer i midten av en transaksjon som ikke kan rulles tilbake.
+     */
+    @Transactional
+    public void startOppfolgingHvisIkkeAlleredeStartet(Oppfolgingsbruker oppfolgingsbruker, boolean publishOnKafka) {
         String aktoerId = oppfolgingsbruker.getAktoerId();
 
         Oppfolging oppfolgingsstatus = hentOppfolging(aktoerId).orElseGet(() -> {
@@ -402,7 +410,9 @@ public class OppfolgingService {
         if (oppfolgingsstatus != null && !oppfolgingsstatus.isUnderOppfolging()) {
             oppfolgingsPeriodeRepository.start(aktoerId);
             nyeBrukereFeedRepository.leggTil(oppfolgingsbruker);
-            kafkaProducerService.publiserOppfolgingStartet(aktoerId);
+            if (publishOnKafka) {
+                kafkaProducerService.publiserOppfolgingStartet(aktoerId);
+            }
         }
     }
 

--- a/src/test/java/no/nav/veilarboppfolging/service/AktiverBrukerIntegrationTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/AktiverBrukerIntegrationTest.java
@@ -53,7 +53,7 @@ public class AktiverBrukerIntegrationTest {
 
         aktiverBrukerService = new AktiverBrukerService(
                 authService, oppfolgingService,
-                behandleArbeidssokerClient, new NyeBrukereFeedRepository(db),
+                behandleArbeidssokerClient, mock(KafkaProducerService.class), new NyeBrukereFeedRepository(db),
                 DbTestUtils.getTransactor(db)
         );
 

--- a/src/test/java/no/nav/veilarboppfolging/service/AktiverBrukerServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/AktiverBrukerServiceTest.java
@@ -34,7 +34,7 @@ public class AktiverBrukerServiceTest {
                 authService,
                 oppfolgingService,
                 behandleArbeidssokerClient,
-                new NyeBrukereFeedRepository(LocalH2Database.getDb()),
+                mock(KafkaProducerService.class), new NyeBrukereFeedRepository(LocalH2Database.getDb()),
                 DbTestUtils.getTransactor(LocalH2Database.getDb())
         );
     }


### PR DESCRIPTION
Når f.eks /aktiverBruker kalles så blir kafka melding om at oppfølging er startet selv om kallet til Arena feiler og alle endringer skal bli rullet tilbake.