### PR TITLE
Legge til modialogin som godkjent clientId

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -48,3 +48,6 @@ spec:
         mountPath: /var/run/secrets/nais.io/vault
       - kvPath: /oracle/data/dev/config/veilarboppfolging_q1
         mountPath: /var/run/secrets/nais.io/oracle_config
+  env:
+    name: MODIABLOGIN_OPENAM_CLIENT_ID
+    value: "modia-q1"

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -47,3 +47,6 @@ spec:
         mountPath: /var/run/secrets/nais.io/vault
       - kvPath: /oracle/data/prod/config/veilarboppfolging
         mountPath: /var/run/secrets/nais.io/oracle_config
+  env:
+    name: MODIABLOGIN_OPENAM_CLIENT_ID
+    value: "modia-p"

--- a/src/main/java/no/nav/veilarboppfolging/config/EnvironmentProperties.java
+++ b/src/main/java/no/nav/veilarboppfolging/config/EnvironmentProperties.java
@@ -13,6 +13,8 @@ public class EnvironmentProperties {
 
     private String veilarbloginOpenAmClientId;
 
+    private String modialoginOpenAmClientId;
+
     private String openAmRefreshUrl;
 
     private String openAmRedirectUrl;

--- a/src/main/java/no/nav/veilarboppfolging/config/FilterConfig.java
+++ b/src/main/java/no/nav/veilarboppfolging/config/FilterConfig.java
@@ -44,9 +44,13 @@ public class FilterConfig {
     }
 
     private OidcAuthenticatorConfig openAmAuthConfig(EnvironmentProperties properties) {
+        List<String> clientIds = List.of(
+                properties.getVeilarbloginOpenAmClientId(),
+                properties.getModialoginOpenAmClientId()
+        );
         return new OidcAuthenticatorConfig()
                 .withDiscoveryUrl(properties.getOpenAmDiscoveryUrl())
-                .withClientId(properties.getVeilarbloginOpenAmClientId())
+                .withClientIds(clientIds)
                 .withIdTokenCookieName(OPEN_AM_ID_TOKEN_COOKIE_NAME)
                 .withRefreshTokenCookieName(REFRESH_TOKEN_COOKIE_NAME)
                 .withIdTokenFinder(new UserTokenFinder())

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,7 @@ spring.data.jdbc.repositories.enabled=false
 # From config map "pto-config"
 app.env.openAmDiscoveryUrl=${OPENAM_DISCOVERY_URL}
 app.env.veilarbloginOpenAmClientId=${VEILARBLOGIN_OPENAM_CLIENT_ID}
+app.env.modialoginOpenAmClientId=${MODIABLOGIN_OPENAM_CLIENT_ID}
 app.env.openAmRefreshUrl=${VEILARBLOGIN_OPENAM_REFRESH_URL}
 app.env.openAmRedirectUrl=${OIDC_REDIRECT_URL}
 app.env.openAmIssoRpUsername=${ISSO_RP_USER_USERNAME}


### PR DESCRIPTION
modiapersonoversikt-api kaller appen for å hente ut oppfølgingsinfo.

**NB**: `MODIABLOGIN_OPENAM_CLIENT_ID` mangler i pto-config, og må legges inn der (jeg har ikke rettigheter til å gjøre noe der, men kan lage PR om jeg får skrive rettigheter dit). 