### PR TITLE
Fjernet en ikke kritisk advarsel ang. @Transactional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- Not used, and includes duplicate JSONObject. -->
+                <exclusion>
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
@@ -128,6 +128,7 @@ public class OppfolgingService {
     }
 
     @SneakyThrows
+    @Transactional
     public OppfolgingStatusData startOppfolging(String fnr) {
         String aktorId = authService.getAktorIdOrThrow(fnr);
 
@@ -381,6 +382,7 @@ public class OppfolgingService {
         return Optional.of(o);
     }
 
+    @Transactional
     public void startOppfolgingHvisIkkeAlleredeStartet(String aktorId) {
         startOppfolgingHvisIkkeAlleredeStartet(
                 Oppfolgingsbruker.builder()
@@ -389,6 +391,7 @@ public class OppfolgingService {
         );
     }
 
+    @Transactional
     public void startOppfolgingHvisIkkeAlleredeStartet(Oppfolgingsbruker oppfolgingsbruker) {
         startOppfolgingHvisIkkeAlleredeStartet(oppfolgingsbruker, true);
     }
@@ -450,7 +453,7 @@ public class OppfolgingService {
         String aktorId = authService.getAktorIdOrThrow(fnr);
         Optional<ArenaOppfolgingTilstand> arenaOppfolgingTilstand = arenaOppfolgingService.hentOppfolgingTilstand(fnr);
 
-        arenaOppfolgingTilstand.ifPresent((oppfolgingTilstand) -> {
+        arenaOppfolgingTilstand.ifPresent(oppfolgingTilstand -> {
             Optional<OppfolgingTable> maybeOppfolging = ofNullable(oppfolgingsStatusRepository.fetch(aktorId));
 
             boolean erBrukerUnderOppfolging = maybeOppfolging.map(OppfolgingTable::isUnderOppfolging).orElse(false);
@@ -474,7 +477,7 @@ public class OppfolgingService {
                         erSykmeldtMedArbeidsgiver,
                         erInaktivIArena,
                         aktorId,
-                        arenaOppfolgingTilstand.toString());
+                        arenaOppfolgingTilstand);
 
                 if (sjekkIArenaOmBrukerSkalAvsluttes) {
                     sjekkOgOppdaterBrukerDirekteFraArena(fnr, oppfolgingTilstand, maybeOppfolging.get());
@@ -505,7 +508,7 @@ public class OppfolgingService {
                     erInaktivIArena,
                     skalAvsluttes,
                     oppfolging.getAktorId(),
-                    arenaOppfolgingTilstand.toString());
+                    arenaOppfolgingTilstand);
 
             if (skalAvsluttes) {
                 String aktorId = authService.getAktorIdOrThrow(fnr);

--- a/src/test/java/no/nav/veilarboppfolging/service/IservServiceIntegrationTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/IservServiceIntegrationTest.java
@@ -15,8 +15,10 @@ import org.junit.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import static java.time.ZonedDateTime.now;
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -69,7 +71,7 @@ public class IservServiceIntegrationTest {
         IservMapper iservMapper = utmeldingRepository.eksisterendeIservBruker(veilarbArenaOppfolging);
         assertThat(iservMapper).isNotNull();
         assertThat(iservMapper.getAktor_Id()).isEqualTo(AKTORID);
-        assertThat(iservMapper.getIservSiden()).isEqualTo(iservFraDato);
+        assertThat(iservMapper.getIservSiden().truncatedTo(MILLIS)).isEqualTo(iservFraDato.truncatedTo(MILLIS));
     }
 
     @Test
@@ -84,7 +86,7 @@ public class IservServiceIntegrationTest {
         IservMapper iservMapper = utmeldingRepository.eksisterendeIservBruker(veilarbArenaOppfolging);
         assertThat(iservMapper).isNotNull();
         assertThat(iservMapper.getAktor_Id()).isEqualTo(AKTORID);
-        assertThat(iservMapper.getIservSiden()).isEqualTo(veilarbArenaOppfolging.getIserv_fra_dato());
+        assertThat(iservMapper.getIservSiden().truncatedTo(MILLIS)).isEqualTo(veilarbArenaOppfolging.getIserv_fra_dato().truncatedTo(MILLIS));
     }
 
     @Test


### PR DESCRIPTION
Gyldig code smell, men ingen konsekvens i denne konteksten. Fjernet et problem ved build og en feil ved kjøring av to tester (sammenligning av nanosekunder).