### PR TITLE
La til uuid på oppfølgingsperioder

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/controller/domain/OppfolgingPeriodeDTO.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/domain/OppfolgingPeriodeDTO.java
@@ -5,11 +5,13 @@ import lombok.experimental.Accessors;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Data
 @Accessors(chain = true)
 public class OppfolgingPeriodeDTO {
 
+    public UUID uuid;
     public String aktorId;
     public String veileder;
     public ZonedDateTime startDato;

--- a/src/main/java/no/nav/veilarboppfolging/domain/Oppfolgingsperiode.java
+++ b/src/main/java/no/nav/veilarboppfolging/domain/Oppfolgingsperiode.java
@@ -5,10 +5,12 @@ import lombok.Value;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Value
 @Builder(toBuilder = true)
 public class Oppfolgingsperiode {
+    UUID uuid;
     String aktorId;
     String veileder;
     ZonedDateTime startDato;

--- a/src/main/java/no/nav/veilarboppfolging/repository/OppfolgingsPeriodeRepository.java
+++ b/src/main/java/no/nav/veilarboppfolging/repository/OppfolgingsPeriodeRepository.java
@@ -11,6 +11,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.UUID;
 
 import static no.nav.veilarboppfolging.repository.OppfolgingsStatusRepository.AKTOR_ID;
 import static no.nav.veilarboppfolging.repository.OppfolgingsStatusRepository.UNDER_OPPFOLGING;
@@ -22,7 +23,7 @@ public class OppfolgingsPeriodeRepository {
     private final JdbcTemplate db;
 
     private final static String hentOppfolingsperioderSQL =
-            "SELECT aktor_id, avslutt_veileder, startdato, sluttdato, avslutt_begrunnelse " +
+            "SELECT uuid, aktor_id, avslutt_veileder, startdato, sluttdato, avslutt_begrunnelse " +
                     "FROM OPPFOLGINGSPERIODE ";
 
     @Autowired
@@ -69,11 +70,26 @@ public class OppfolgingsPeriodeRepository {
         );
     }
 
+    public List<Oppfolgingsperiode> hentOppfolgingsPeriodeUtenUuid() {
+        return db.query(
+                hentOppfolingsperioderSQL + "WHERE uuid is null FETCH NEXT 1000 ROWS ONLY",
+                OppfolgingsPeriodeRepository::mapTilOppfolgingsperiode
+        );
+    }
+
+    public void initialiserUuidPaOppfolgingsperiode(Oppfolgingsperiode oppfolgingsperiode) {
+        Timestamp startDato = Timestamp.valueOf(oppfolgingsperiode.getStartDato().toLocalDateTime());
+
+        db.update("UPDATE OPPFOLGINGSPERIODE SET uuid = ? WHERE uuid IS NULL AND aktor_id = ? AND startDato = ?",
+                UUID.randomUUID(), oppfolgingsperiode.getAktorId(), startDato
+        );
+    }
+
     private void insert(String aktorId) {
         db.update("" +
-                        "INSERT INTO OPPFOLGINGSPERIODE(aktor_id, startDato, oppdatert) " +
-                        "VALUES (?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
-                aktorId);
+                        "INSERT INTO OPPFOLGINGSPERIODE(uuid, aktor_id, startDato, oppdatert) " +
+                        "VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+                UUID.randomUUID(), aktorId);
     }
 
     private void setActive(String aktorId) {
@@ -116,7 +132,9 @@ public class OppfolgingsPeriodeRepository {
     }
 
     private static Oppfolgingsperiode mapTilOppfolgingsperiode(ResultSet result, int row) throws SQLException {
+        String uuid = result.getString("uuid");
         return Oppfolgingsperiode.builder()
+                .uuid(uuid != null ? UUID.fromString(uuid) : null)
                 .aktorId(result.getString("aktor_id"))
                 .veileder(result.getString("avslutt_veileder"))
                 .startDato(hentZonedDateTime(result, "startdato"))

--- a/src/main/java/no/nav/veilarboppfolging/schedule/OppfolgingsperiodeUuidSchedule.java
+++ b/src/main/java/no/nav/veilarboppfolging/schedule/OppfolgingsperiodeUuidSchedule.java
@@ -1,0 +1,30 @@
+package no.nav.veilarboppfolging.schedule;
+
+import lombok.RequiredArgsConstructor;
+import no.nav.common.job.leader_election.LeaderElectionClient;
+import no.nav.veilarboppfolging.domain.Oppfolgingsperiode;
+import no.nav.veilarboppfolging.repository.OppfolgingsPeriodeRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OppfolgingsperiodeUuidSchedule {
+
+    private final static long TEN_SECONDS = 10 * 1000;
+
+    private final LeaderElectionClient leaderElectionClient;
+
+    private final OppfolgingsPeriodeRepository oppfolgingsPeriodeRepository;
+
+    @Scheduled(initialDelay = TEN_SECONDS, fixedRate = 1000)
+    public void settIdeerPaFeedElementer() {
+        if (leaderElectionClient.isLeader()) {
+            List<Oppfolgingsperiode> oppfolgingsperioder = oppfolgingsPeriodeRepository.hentOppfolgingsPeriodeUtenUuid();
+            oppfolgingsperioder.forEach(oppfolgingsPeriodeRepository::initialiserUuidPaOppfolgingsperiode);
+        }
+    }
+
+}

--- a/src/main/java/no/nav/veilarboppfolging/utils/DtoMappers.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/DtoMappers.java
@@ -80,6 +80,7 @@ public class DtoMappers {
 
     public static OppfolgingPeriodeDTO tilDTO(Oppfolgingsperiode oppfolgingsperiode, boolean erInternBruker) {
         OppfolgingPeriodeDTO periode = new OppfolgingPeriodeDTO()
+                .setUuid(oppfolgingsperiode.getUuid())
                 .setSluttDato(oppfolgingsperiode.getSluttDato())
                 .setStartDato(oppfolgingsperiode.getStartDato())
                 .setKvpPerioder(

--- a/src/main/resources/db/migration/V1_68__oppfolgingsperiode_id.sql
+++ b/src/main/resources/db/migration/V1_68__oppfolgingsperiode_id.sql
@@ -1,0 +1,4 @@
+
+-- This is an inefficient way of storing UUID, but it should not be a problem at the current scale
+-- After migrating to postgres a proper column type can be used
+ALTER TABLE OPPFOLGINGSPERIODE ADD UUID CHAR(36);

--- a/src/test/java/no/nav/veilarboppfolging/repository/OppfolgingsperiodeRepositoryTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/repository/OppfolgingsperiodeRepositoryTest.java
@@ -1,0 +1,55 @@
+package no.nav.veilarboppfolging.repository;
+
+import no.nav.veilarboppfolging.domain.Oppfolgingsperiode;
+import no.nav.veilarboppfolging.test.DbTestUtils;
+import no.nav.veilarboppfolging.test.LocalH2Database;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class OppfolgingsperiodeRepositoryTest {
+
+    private JdbcTemplate db = LocalH2Database.getDb();
+
+    private OppfolgingsStatusRepository oppfolgingsStatusRepository = new OppfolgingsStatusRepository(db);
+
+    private OppfolgingsPeriodeRepository oppfolgingsPeriodeRepository = new OppfolgingsPeriodeRepository(db);
+
+    @Before
+    public void cleanup() {
+        DbTestUtils.cleanupTestDb();
+    }
+
+    @Test
+    public void skal_hente_perioder_uten_uuid_og_sette_uuid() {
+        String aktorId1 = "aktorid1";
+        String aktorId2 = "aktorid2";
+
+        oppfolgingsStatusRepository.opprettOppfolging(aktorId1);
+        oppfolgingsStatusRepository.opprettOppfolging(aktorId2);
+
+        db.update("INSERT INTO OPPFOLGINGSPERIODE(aktor_id, startDato, oppdatert) " +
+                        "VALUES (?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)", aktorId1);
+
+        db.update("INSERT INTO OPPFOLGINGSPERIODE(aktor_id, startDato, oppdatert) " +
+                "VALUES (?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)", aktorId2);
+
+
+        List<Oppfolgingsperiode> oppfolgingsperioder1 = oppfolgingsPeriodeRepository.hentOppfolgingsPeriodeUtenUuid();
+
+        assertEquals(2, oppfolgingsperioder1.size());
+
+        oppfolgingsPeriodeRepository.initialiserUuidPaOppfolgingsperiode(oppfolgingsperioder1.get(0));
+
+        List<Oppfolgingsperiode> oppfolgingsperioder2 = oppfolgingsPeriodeRepository.hentOppfolgingsPeriodeUtenUuid();
+
+        assertEquals(1, oppfolgingsperioder2.size());
+        assertEquals(aktorId2, oppfolgingsperioder2.get(0).getAktorId());
+    }
+
+
+}


### PR DESCRIPTION
Denne PRen blir en 2-stegs prosess hvor det første steget (denne comitten) blir å legge til kolonnen og sette UUID på alle oppfølgingsperiodene, og det andre steget legger på constrains for PK og "non null" når alle perioder har fått en id.