### PR TITLE
Lager endepunkt for å hente ut oppfølgingsperiode på id

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/controller/OppfolgingController.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/OppfolgingController.java
@@ -169,10 +169,11 @@ public class OppfolgingController {
     }
 
     @GetMapping("/oppfolgingsperiode/{uuid}")
-    public OppfolgingPeriodeMinimalDTO hentOppfolgingsPeriode(@RequestParam(value = "fnr", required = false) String fnr, @PathVariable String uuid){
-        String fodselsnummer = authService.hentIdentForEksternEllerIntern(fnr);
-        authService.sjekkLesetilgangMedFnr(fodselsnummer);
-        return tilOppfolgingPeriodeMinimalDTO(oppfolgingService.hentPeriode(uuid));
+    public OppfolgingPeriodeMinimalDTO hentOppfolgingsPeriode(@PathVariable String uuid){
+        var periode = oppfolgingService.hentPeriode(uuid);
+        authService.sjekkLesetilgangMedAktorId(periode.getAktorId());
+
+        return tilOppfolgingPeriodeMinimalDTO(periode);
 
     }
 

--- a/src/main/java/no/nav/veilarboppfolging/controller/OppfolgingController.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/OppfolgingController.java
@@ -168,11 +168,11 @@ public class OppfolgingController {
         return oppfolgingService.hentVeilederTilgang(fnr);
     }
 
-    @GetMapping("/hentPeriode")
+    @GetMapping("/oppfolgingsperiode/{uuid}")
     public OppfolgingPeriodeMinimalDTO hentOppfolgingsPeriode(@RequestParam(value = "fnr", required = false) String fnr, @PathVariable String uuid){
         String fodselsnummer = authService.hentIdentForEksternEllerIntern(fnr);
         authService.sjekkLesetilgangMedFnr(fodselsnummer);
-        return tilOppfolgingPeriodeMinimalDTO(oppfolgingService.hentPeriode(uuid), authService.erInternBruker());
+        return tilOppfolgingPeriodeMinimalDTO(oppfolgingService.hentPeriode(uuid));
 
     }
 

--- a/src/main/java/no/nav/veilarboppfolging/controller/OppfolgingController.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/OppfolgingController.java
@@ -14,8 +14,8 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static no.nav.veilarboppfolging.utils.DtoMappers.tilDTO;
 import static no.nav.veilarboppfolging.utils.DtoMappers.tilDto;
+import static no.nav.veilarboppfolging.utils.DtoMappers.*;
 
 @RequestMapping("/api/oppfolging")
 @RestController
@@ -168,13 +168,21 @@ public class OppfolgingController {
         return oppfolgingService.hentVeilederTilgang(fnr);
     }
 
+    @GetMapping("/hentPeriode")
+    public OppfolgingPeriodeMinimalDTO hentOppfolgingsPeriode(@RequestParam(value = "fnr", required = false) String fnr, @PathVariable String uuid){
+        String fodselsnummer = authService.hentIdentForEksternEllerIntern(fnr);
+        authService.sjekkLesetilgangMedFnr(fodselsnummer);
+        return tilOppfolgingPeriodeMinimalDTO(oppfolgingService.hentPeriode(uuid), authService.erInternBruker());
+
+    }
+
     @GetMapping("/oppfolgingsperioder")
     public List<OppfolgingPeriodeDTO> hentOppfolgingsperioder(@RequestParam("fnr") String fnr) {
         authService.skalVereSystemBruker();
 
         return oppfolgingService.hentOppfolgingsperioder(fnr)
                 .stream()
-                .map(op -> tilDTO(op, true))
+                .map(op -> tilOppfolgingPeriodeDTO(op, true))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/no/nav/veilarboppfolging/controller/domain/OppfolgingPeriodeMinimalDTO.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/domain/OppfolgingPeriodeMinimalDTO.java
@@ -1,0 +1,14 @@
+package no.nav.veilarboppfolging.controller.domain;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.time.ZonedDateTime;
+
+@Data
+@Accessors(chain = true)
+public class OppfolgingPeriodeMinimalDTO {
+    private String id;
+    private ZonedDateTime startDato;
+    private ZonedDateTime sluttDato;
+}

--- a/src/main/java/no/nav/veilarboppfolging/controller/domain/OppfolgingPeriodeMinimalDTO.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/domain/OppfolgingPeriodeMinimalDTO.java
@@ -4,11 +4,12 @@ import lombok.Data;
 import lombok.experimental.Accessors;
 
 import java.time.ZonedDateTime;
+import java.util.UUID;
 
 @Data
 @Accessors(chain = true)
 public class OppfolgingPeriodeMinimalDTO {
-    private String id;
+    private UUID uuid;
     private ZonedDateTime startDato;
     private ZonedDateTime sluttDato;
 }

--- a/src/main/java/no/nav/veilarboppfolging/repository/OppfolgingsPeriodeRepository.java
+++ b/src/main/java/no/nav/veilarboppfolging/repository/OppfolgingsPeriodeRepository.java
@@ -54,6 +54,13 @@ public class OppfolgingsPeriodeRepository {
                         pageSize);
     }
 
+    public Oppfolgingsperiode hentOppfolgingsperiode(String id) {
+        return db.queryForObject(hentOppfolingsperioderSQL +
+                        "WHERE UUID = ?",
+                Oppfolgingsperiode.class,
+                id
+        );
+    }
     public List<Oppfolgingsperiode> hentOppfolgingsperioder(String aktorId) {
         return db.query(hentOppfolingsperioderSQL +
                         "WHERE aktor_id = ?",

--- a/src/main/java/no/nav/veilarboppfolging/repository/OppfolgingsPeriodeRepository.java
+++ b/src/main/java/no/nav/veilarboppfolging/repository/OppfolgingsPeriodeRepository.java
@@ -54,13 +54,14 @@ public class OppfolgingsPeriodeRepository {
                         pageSize);
     }
 
-    public Oppfolgingsperiode hentOppfolgingsperiode(String id) {
+    public Oppfolgingsperiode hentOppfolgingsperiode(String uuid) {
         return db.queryForObject(hentOppfolingsperioderSQL +
                         "WHERE UUID = ?",
-                Oppfolgingsperiode.class,
-                id
+                OppfolgingsPeriodeRepository::mapTilOppfolgingsperiode,
+                uuid
         );
     }
+
     public List<Oppfolgingsperiode> hentOppfolgingsperioder(String aktorId) {
         return db.query(hentOppfolingsperioderSQL +
                         "WHERE aktor_id = ?",

--- a/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
@@ -339,6 +339,10 @@ public class OppfolgingService {
                 .build();
     }
 
+    public Oppfolgingsperiode hentPeriode(String uuid) {
+        return oppfolgingsPeriodeRepository.hentOppfolgingsperiode(uuid);
+    }
+
     @SneakyThrows
     public Optional<Oppfolging> hentOppfolging(String aktorId) {
         OppfolgingTable t = oppfolgingsStatusRepository.fetch(aktorId);

--- a/src/main/java/no/nav/veilarboppfolging/utils/DtoMappers.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/DtoMappers.java
@@ -54,7 +54,7 @@ public class DtoMappers {
                 .setReservasjonKRR(oppfolgingStatusData.reservasjonKRR)
                 .setOppfolgingUtgang(oppfolgingStatusData.getOppfolgingUtgang())
                 .setKanReaktiveres(oppfolgingStatusData.kanReaktiveres)
-                .setOppfolgingsPerioder(oppfolgingStatusData.oppfolgingsperioder.stream().map(o -> tilDTO(o, erInternBruker)).collect(toList()))
+                .setOppfolgingsPerioder(oppfolgingStatusData.oppfolgingsperioder.stream().map(o -> tilOppfolgingPeriodeDTO(o, erInternBruker)).collect(toList()))
                 .setInaktiveringsdato(oppfolgingStatusData.inaktiveringsdato)
                 .setGjeldendeEskaleringsvarsel(tilDto(oppfolgingStatusData.getGjeldendeEskaleringsvarsel(), erInternBruker))
                 .setErIkkeArbeidssokerUtenOppfolging(oppfolgingStatusData.getErSykmeldtMedArbeidsgiver())
@@ -78,7 +78,7 @@ public class DtoMappers {
         return status;
     }
 
-    public static OppfolgingPeriodeDTO tilDTO(Oppfolgingsperiode oppfolgingsperiode, boolean erInternBruker) {
+    public static OppfolgingPeriodeDTO tilOppfolgingPeriodeDTO(Oppfolgingsperiode oppfolgingsperiode, boolean erInternBruker) {
         OppfolgingPeriodeDTO periode = new OppfolgingPeriodeDTO()
                 .setUuid(oppfolgingsperiode.getUuid())
                 .setSluttDato(oppfolgingsperiode.getSluttDato())
@@ -95,6 +95,13 @@ public class DtoMappers {
         }
 
         return periode;
+    }
+
+    public static OppfolgingPeriodeMinimalDTO tilOppfolgingPeriodeMinimalDTO(Oppfolgingsperiode oppfolgingsperiode, boolean erInternBruker) {
+        return new OppfolgingPeriodeMinimalDTO()
+                .setSluttDato(oppfolgingsperiode.getSluttDato())
+                .setStartDato(oppfolgingsperiode.getStartDato());
+
     }
 
     public static KvpPeriodeDTO tilDTO(Kvp kvp) {

--- a/src/main/java/no/nav/veilarboppfolging/utils/DtoMappers.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/DtoMappers.java
@@ -97,8 +97,9 @@ public class DtoMappers {
         return periode;
     }
 
-    public static OppfolgingPeriodeMinimalDTO tilOppfolgingPeriodeMinimalDTO(Oppfolgingsperiode oppfolgingsperiode, boolean erInternBruker) {
+    public static OppfolgingPeriodeMinimalDTO tilOppfolgingPeriodeMinimalDTO(Oppfolgingsperiode oppfolgingsperiode) {
         return new OppfolgingPeriodeMinimalDTO()
+                .setUuid(oppfolgingsperiode.getUuid())
                 .setSluttDato(oppfolgingsperiode.getSluttDato())
                 .setStartDato(oppfolgingsperiode.getStartDato());
 

--- a/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerIntegrationTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerIntegrationTest.java
@@ -1,0 +1,81 @@
+package no.nav.veilarboppfolging.controller;
+import no.nav.veilarboppfolging.domain.Fnr;
+import no.nav.veilarboppfolging.config.ApplicationTestConfig;
+import no.nav.veilarboppfolging.domain.AktiverArbeidssokerData;
+import no.nav.veilarboppfolging.domain.Innsatsgruppe;
+import no.nav.veilarboppfolging.repository.OppfolgingsPeriodeRepository;
+import no.nav.veilarboppfolging.service.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.dao.EmptyResultDataAccessException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(classes = {ApplicationTestConfig.class})
+class OppfolgingControllerIntegrationTest {
+    private final static String fnr = "123";
+    private final static String aktorId = "321";
+
+
+    @MockBean
+    private AuthService authService;
+
+    @Autowired
+    private OppfolgingController oppfolgingController;
+
+    @Autowired
+    OppfolgingsPeriodeRepository oppfolgingsPeriodeRepository;
+
+    @Autowired
+    SystemOppfolgingController systemOppfolgingController;
+
+    @Test
+    void hentOppfolgingsPeriode_periodeEksistererIkke() throws EmptyResultDataAccessException {
+
+        mockHappyPathBruker();
+
+        assertThrows(EmptyResultDataAccessException.class, () -> {
+            oppfolgingController.hentOppfolgingsPeriode(fnr, "123");
+        });
+    }
+
+    @Test
+    void hentOppfolgingsPeriode_brukerHarEnAktivOppfolgingsPeriode() throws EmptyResultDataAccessException {
+        mockHappyPathVeileder();
+        var aktiverArbeidssokerData = new AktiverArbeidssokerData(new Fnr(fnr), Innsatsgruppe.STANDARD_INNSATS);
+        systemOppfolgingController.aktiverBruker(aktiverArbeidssokerData);
+        var perioder = oppfolgingController.hentOppfolgingsperioder(fnr);
+
+        Assertions.assertEquals(1, perioder.size());
+
+        var forstePeriode = perioder.get(0);
+        var uuid = forstePeriode.uuid;
+        var periode = oppfolgingController.hentOppfolgingsPeriode(fnr, uuid.toString());
+
+        Assertions.assertEquals(uuid, periode.getUuid());
+        Assertions.assertNotNull(forstePeriode.startDato);
+        Assertions.assertEquals(forstePeriode.startDato, periode.getStartDato());
+    }
+
+    private void mockHappyPathBruker() {
+        when(authService.hentIdentForEksternEllerIntern(fnr)).thenReturn(fnr);
+        mockAuthOK();
+    }
+
+    private void mockHappyPathVeileder() {
+        when(authService.erInternBruker()).thenReturn(true);
+        mockAuthOK();
+    }
+
+    private void mockAuthOK() {
+        when(authService.getAktorIdOrThrow(fnr)).thenReturn(aktorId);
+        when(authService.hentIdentForEksternEllerIntern(fnr)).thenReturn(fnr);
+        doNothing().when(authService).sjekkLesetilgangMedFnr(fnr);
+    }
+}

--- a/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerIntegrationTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerIntegrationTest.java
@@ -40,9 +40,7 @@ class OppfolgingControllerIntegrationTest {
 
         mockHappyPathBruker();
 
-        assertThrows(EmptyResultDataAccessException.class, () -> {
-            oppfolgingController.hentOppfolgingsPeriode(fnr, "123");
-        });
+        assertThrows(EmptyResultDataAccessException.class, () -> oppfolgingController.hentOppfolgingsPeriode("123"));
     }
 
     @Test
@@ -56,7 +54,7 @@ class OppfolgingControllerIntegrationTest {
 
         var forstePeriode = perioder.get(0);
         var uuid = forstePeriode.uuid;
-        var periode = oppfolgingController.hentOppfolgingsPeriode(fnr, uuid.toString());
+        var periode = oppfolgingController.hentOppfolgingsPeriode(uuid.toString());
 
         Assertions.assertEquals(uuid, periode.getUuid());
         Assertions.assertNotNull(forstePeriode.startDato);

--- a/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerIntegrationTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerIntegrationTest.java
@@ -13,11 +13,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest(classes = {ApplicationTestConfig.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class OppfolgingControllerIntegrationTest {
     private final static String fnr = "123";
     private final static String aktorId = "321";

--- a/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerTest.java
@@ -1,6 +1,12 @@
 package no.nav.veilarboppfolging.controller;
 
+import no.nav.common.abac.Pep;
+import no.nav.common.auth.context.AuthContextHolder;
+import no.nav.common.client.aktoroppslag.AktorOppslagClient;
+import no.nav.common.client.aktorregister.AktorregisterClient;
+import no.nav.common.health.selftest.SelfTestChecks;
 import no.nav.common.json.JsonUtils;
+import no.nav.common.utils.Credentials;
 import no.nav.veilarboppfolging.domain.Kvp;
 import no.nav.veilarboppfolging.domain.Oppfolgingsperiode;
 import no.nav.veilarboppfolging.service.*;

--- a/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerTest.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static no.nav.veilarboppfolging.utils.DtoMappers.tilDTO;
+import static no.nav.veilarboppfolging.utils.DtoMappers.tilOppfolgingPeriodeDTO;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -75,7 +75,7 @@ public class OppfolgingControllerTest {
 
         String expectedJson = JsonUtils.toJson(
                 perioder.stream()
-                .map(op -> tilDTO(op, true))
+                .map(op -> tilOppfolgingPeriodeDTO(op, true))
                 .collect(Collectors.toList())
         );
 

--- a/src/test/java/no/nav/veilarboppfolging/kafka/KafkaIntegrationTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/kafka/KafkaIntegrationTest.java
@@ -72,7 +72,7 @@ public class KafkaIntegrationTest {
                     konsumertMelding.set(newValue);
                 })).build().start();
 
-        TestUtils.verifiserAsynkront(10, TimeUnit.SECONDS, () -> {
+        TestUtils.verifiserAsynkront(100, TimeUnit.SECONDS, () -> {
             assertEquals(oppfolgingEndret.getAktoerid(), konsumertMelding.get().getAktorId());
         });
     }

--- a/src/test/java/no/nav/veilarboppfolging/repository/OppfolgingFeedRepositoryTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/repository/OppfolgingFeedRepositoryTest.java
@@ -1,31 +1,26 @@
 package no.nav.veilarboppfolging.repository;
 
-import lombok.val;
 import no.nav.veilarboppfolging.domain.AktorId;
-import no.nav.veilarboppfolging.domain.Oppfolgingsperiode;
 import no.nav.veilarboppfolging.domain.kafka.OppfolgingKafkaDTO;
 import no.nav.veilarboppfolging.test.DbTestUtils;
 import no.nav.veilarboppfolging.test.LocalH2Database;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
-import static java.util.Comparator.comparing;
-import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OppfolgingFeedRepositoryTest {
-
-    private static final String AKTOR_ID = randomNumeric(10);
-    private static final String VEILEDER = "1234";
 
     private OppfolgingFeedRepository oppfolgingFeedRepository = new OppfolgingFeedRepository(LocalH2Database.getDb());
     private OppfolgingsPeriodeRepository oppfolgingsPeriodeRepository = new OppfolgingsPeriodeRepository(LocalH2Database.getDb());
@@ -112,6 +107,48 @@ public class OppfolgingFeedRepositoryTest {
 
         List<AktorId> aktorIds = oppfolgingFeedRepository.hentAlleBrukereUnderOppfolging();
         assertThat(aktorIds.size()).isEqualTo(10);
+    }
+
+    @Test
+    public void hentOppfolgingsperiode_ingenTreff_skalKasteException() {
+        assertThrows(EmptyResultDataAccessException.class, () -> oppfolgingsPeriodeRepository.hentOppfolgingsperiode("123"));
+    }
+
+    @Test
+    public void hentOppfolgingsperiode_periodeFinnes_skalKasteException() {
+        String aktorId = randomNumeric(10);
+        oppfolgingsStatusRepository.opprettOppfolging(aktorId);
+        oppfolgingsPeriodeRepository.start(aktorId);
+        var perioder = oppfolgingsPeriodeRepository.hentOppfolgingsperioder(aktorId);
+
+        Assert.assertEquals(1, perioder.size());
+
+        var periode = oppfolgingsPeriodeRepository.hentOppfolgingsperiode(perioder.get(0).getUuid().toString());
+
+        assertNotNull(periode);
+        assertEquals(perioder.get(0).getStartDato(), periode.getStartDato());
+        assertEquals(perioder.get(0).getSluttDato(), periode.getSluttDato());
+
+    }
+
+    @Test
+    public void hentOppfolgingsperiode_flerePerioder_skalKasteException() {
+        String aktorId = randomNumeric(10);
+        oppfolgingsStatusRepository.opprettOppfolging(aktorId);
+        oppfolgingsPeriodeRepository.start(aktorId);
+        oppfolgingsPeriodeRepository.avslutt(aktorId, "V123", "Fordi atte");
+        oppfolgingsPeriodeRepository.start(aktorId);
+
+        var ikkeAvsluttetPeriode = oppfolgingsPeriodeRepository.hentOppfolgingsperioder(aktorId).stream().filter(x -> x.getSluttDato() != null);
+
+        var eldstePeriode = ikkeAvsluttetPeriode.findFirst().orElse(null);
+
+        var periode = oppfolgingsPeriodeRepository.hentOppfolgingsperiode(eldstePeriode.getUuid().toString());
+
+        assertNotNull(periode);
+        assertEquals(eldstePeriode.getStartDato(), periode.getStartDato());
+        assertEquals(eldstePeriode.getSluttDato(), periode.getSluttDato());
+
     }
 
     private void createAntallTestBrukere(int antall) {

--- a/src/test/java/no/nav/veilarboppfolging/utils/DtoMappersTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/utils/DtoMappersTest.java
@@ -14,7 +14,7 @@ public class DtoMappersTest {
                 .kvpPerioder(null)
                 .build();
 
-        OppfolgingPeriodeDTO periodeDTO = DtoMappers.tilDTO(oppfolgingsperiode, false);
+        OppfolgingPeriodeDTO periodeDTO = DtoMappers.tilOppfolgingPeriodeDTO(oppfolgingsperiode, false);
         assertTrue(periodeDTO.kvpPerioder.isEmpty());
     }
 

--- a/src/test/resources/oracle-mock.sql
+++ b/src/test/resources/oracle-mock.sql
@@ -1,6 +1,6 @@
 -- H2 does not have DBMS_LOB.COMPARE so we need to provide a mock
-CREATE SCHEMA DBMS_LOB;
-    CREATE ALIAS DBMS_LOB.COMPARE AS '
+CREATE SCHEMA IF NOT EXISTS DBMS_LOB;
+    CREATE ALIAS IF NOT EXISTS DBMS_LOB.COMPARE AS '
     int compare(String lob_1, String lob_2) {
         return lob_1.equals(lob_2) ? 0 : -1;
     }


### PR DESCRIPTION
For å gjøre det lettere å kommunisere mellom apper hvilken oppfølgingsperiode det refereres til.
Eller mer spesifikt at man skal kunne be om antall uleste dialoger i en oppfølgingsperiode uten å sende datoene: https://trello.com/c/IRX9SKwV/270-tidligere-plan-ulest-dialog