### PR TITLE
Flyttet lagring av kafka meldinger inn i transaksjon

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/service/VeilederTilordningService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/VeilederTilordningService.java
@@ -166,11 +166,12 @@ public class VeilederTilordningService {
             veilederTilordningerRepository.upsertVeilederTilordning(aktorId, veileder);
             veilederHistorikkRepository.insertTilordnetVeilederForAktorId(aktorId, veileder);
             oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(aktorId);
-        });
 
-        log.debug(String.format("Veileder %s tilordnet aktoer %s", veileder, aktorId));
-        kafkaProducerService.publiserEndringPaNyForVeileder(aktorId, true);
-        kafkaProducerService.publiserVeilederTilordnet(aktorId, veileder);
+            kafkaProducerService.publiserEndringPaNyForVeileder(aktorId, true);
+            kafkaProducerService.publiserVeilederTilordnet(aktorId, veileder);
+
+            log.debug(String.format("Veileder %s tilordnet aktoer %s", veileder, aktorId));
+        });
     }
 
     static boolean kanTilordneVeileder(String eksisterendeVeileder, VeilederTilordning veilederTilordning) {


### PR DESCRIPTION
Alle database operasjoner burde gjøres i samme transaksjon slik at det er garantert at meldingen blir produsert