### PR TITLE
Flyttet oppdatering av manuell status ut i eget endepunkt

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/client/dkif/DkifKontaktinfo.java
+++ b/src/main/java/no/nav/veilarboppfolging/client/dkif/DkifKontaktinfo.java
@@ -1,8 +1,10 @@
 package no.nav.veilarboppfolging.client.dkif;
 
 import lombok.Data;
+import lombok.experimental.Accessors;
 
 @Data
+@Accessors(chain = true)
 public class DkifKontaktinfo {
     String personident;
     boolean kanVarsles;

--- a/src/main/java/no/nav/veilarboppfolging/controller/v2/ManuellStatusController.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/v2/ManuellStatusController.java
@@ -1,0 +1,31 @@
+package no.nav.veilarboppfolging.controller.v2;
+
+import lombok.RequiredArgsConstructor;
+import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppfolging.service.AuthService;
+import no.nav.veilarboppfolging.service.ManuellStatusService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/manuell")
+public class ManuellStatusController {
+
+    private final AuthService authService;
+
+    private final ManuellStatusService manuellStatusService;
+
+    /**
+     * Brukes av veilarbpersonflatefs for å manuelt trigge synkronisering av manuell status med reservasjon fra DKIF(KRR).
+     * @param fnr fnr/dnr til bruker som synkroniseringen skal gjøres på.
+     */
+    @PostMapping("/synkroniser-med-dkif")
+    public void synkroniserManuellStatusMedDkif(@RequestParam Fnr fnr) {
+        authService.skalVereInternBruker();
+        manuellStatusService.synkroniserManuellStatusMedDkif(fnr);
+    }
+
+}

--- a/src/main/java/no/nav/veilarboppfolging/service/ManuellStatusService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/ManuellStatusService.java
@@ -82,24 +82,29 @@ public class ManuellStatusService {
     public void synkroniserManuellStatusMedDkif(Fnr fnr) {
         AktorId aktorId = authService.getAktorIdOrThrow(fnr);
 
-        // Bruker er allerede manuell, trenger ikke å sjekke i DKIF
-        if (erManuell(aktorId)) {
-            return;
-        }
-
         DkifKontaktinfo dkifKontaktinfo = hentDkifKontaktinfo(fnr);
 
         if (dkifKontaktinfo.isReservert()) {
-            var manuellStatus = new ManuellStatus()
-                    .setAktorId(aktorId.get())
-                    .setManuell(true)
-                    .setDato(ZonedDateTime.now())
-                    .setBegrunnelse("Brukeren er reservert i Kontakt- og reservasjonsregisteret")
-                    .setOpprettetAv(SYSTEM);
-
-            log.info("Bruker er reservert i KRR, setter bruker aktorId={} til manuell", aktorId);
-            oppdaterManuellStatus(aktorId, manuellStatus);
+            settBrukerTilManuellGrunnetReservasjonIKRR(aktorId);
         }
+    }
+
+    public void settBrukerTilManuellGrunnetReservasjonIKRR(AktorId aktorId) {
+        // Hvis bruker allerede er manuell så trenger vi ikke å sette status på nytt
+        if (erManuell(aktorId)) {
+            log.info("Bruker er allerede manuell og trenger ikke å oppdateres med reservasjon fra KRR");
+            return;
+        }
+
+        var manuellStatus = new ManuellStatus()
+                .setAktorId(aktorId.get())
+                .setManuell(true)
+                .setDato(ZonedDateTime.now())
+                .setBegrunnelse("Brukeren er reservert i Kontakt- og reservasjonsregisteret")
+                .setOpprettetAv(SYSTEM);
+
+        log.info("Bruker er reservert i KRR, setter bruker aktorId={} til manuell", aktorId);
+        oppdaterManuellStatus(aktorId, manuellStatus);
     }
 
     public void settDigitalBruker(Fnr fnr) {

--- a/src/main/java/no/nav/veilarboppfolging/service/ManuellStatusService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/ManuellStatusService.java
@@ -144,13 +144,10 @@ public class ManuellStatusService {
 
     public DkifKontaktinfo hentDkifKontaktinfo(Fnr fnr){
         return dkifClient.hentKontaktInfo(fnr)
-                .orElseGet(() -> {
-                    DkifKontaktinfo fallbackKontaktInfo = new DkifKontaktinfo();
-                    fallbackKontaktInfo.setPersonident(fnr.get());
-                    fallbackKontaktInfo.setKanVarsles(true);
-                    fallbackKontaktInfo.setReservert(false);
-                    return fallbackKontaktInfo;
-                });
+                .orElseGet(() -> new DkifKontaktinfo()
+                .setPersonident(fnr.get())
+                .setKanVarsles(true)
+                .setReservert(false));
     }
 
     private void oppdaterManuellStatus(AktorId aktorId, ManuellStatus manuellStatus) {

--- a/src/test/java/no/nav/veilarboppfolging/config/ClientTestConfig.java
+++ b/src/test/java/no/nav/veilarboppfolging/config/ClientTestConfig.java
@@ -61,12 +61,12 @@ public class ClientTestConfig {
         return new AktorregisterClient() {
             @Override
             public Fnr hentFnr(AktorId aktorId) {
-                return null;
+                return Fnr.of("fnr-" + aktorId.get());
             }
 
             @Override
             public AktorId hentAktorId(Fnr fnr) {
-                return new AktorId(fnr.get());
+                return new AktorId("aktorId-" + fnr.get());
             }
 
             @Override

--- a/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerIntegrationTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerIntegrationTest.java
@@ -114,5 +114,7 @@ class OppfolgingControllerIntegrationTest {
 
         when(authContextHolder.erSystemBruker()).thenReturn(true);
         when(aktorOppslagClient.hentAktorId(FNR)).thenReturn(AKTOR_ID);
+        when(aktorOppslagClient.hentFnr(AKTOR_ID)).thenReturn(FNR);
+
     }
 }

--- a/src/test/java/no/nav/veilarboppfolging/controller/v2/ManuellStatusControllerTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/v2/ManuellStatusControllerTest.java
@@ -1,0 +1,45 @@
+package no.nav.veilarboppfolging.controller.v2;
+
+import no.nav.veilarboppfolging.service.AuthService;
+import no.nav.veilarboppfolging.service.ManuellStatusService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static no.nav.veilarboppfolging.test.TestData.TEST_FNR;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@WebMvcTest(controllers = ManuellStatusController.class)
+public class ManuellStatusControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private ManuellStatusService manuellStatusService;
+
+    @Test
+    public void synkroniserManuellStatusMedDkif__should_only_be_used_by_internal_users() throws Exception {
+        mockMvc.perform(post("/api/v2/manuell/synkroniser-med-dkif")
+                .queryParam("fnr", TEST_FNR.get()));
+
+        verify(authService, times(1)).skalVereInternBruker();
+    }
+
+    @Test
+    public void synkroniserManuellStatusMedDkif__should_synchronize() throws Exception {
+        mockMvc.perform(post("/api/v2/manuell/synkroniser-med-dkif")
+                .queryParam("fnr", TEST_FNR.get()));
+
+        verify(manuellStatusService, times(1)).synkroniserManuellStatusMedDkif(TEST_FNR);
+    }
+
+
+}

--- a/src/test/java/no/nav/veilarboppfolging/kafka/KafkaIntegrationTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/kafka/KafkaIntegrationTest.java
@@ -84,7 +84,7 @@ public class KafkaIntegrationTest {
                 .build()
                 .start();
 
-        TestUtils.verifiserAsynkront(100, TimeUnit.SECONDS, () -> {
+        TestUtils.verifiserAsynkront(15, TimeUnit.SECONDS, () -> {
             assertEquals(oppfolgingEndret.getAktoerid(), konsumertMelding.get().getAktorId());
         });
     }

--- a/src/test/java/no/nav/veilarboppfolging/service/AktiverBrukerIntegrationTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/AktiverBrukerIntegrationTest.java
@@ -4,6 +4,7 @@ import io.vavr.control.Try;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
 import no.nav.veilarboppfolging.client.behandle_arbeidssoker.BehandleArbeidssokerClient;
+import no.nav.veilarboppfolging.client.dkif.DkifKontaktinfo;
 import no.nav.veilarboppfolging.controller.request.AktiverArbeidssokerData;
 import no.nav.veilarboppfolging.domain.Innsatsgruppe;
 import no.nav.veilarboppfolging.domain.Oppfolging;
@@ -35,6 +36,8 @@ public class AktiverBrukerIntegrationTest {
 
     private AktiverBrukerService aktiverBrukerService;
 
+    private ManuellStatusService manuellStatusService;
+
     private final Fnr FNR = Fnr.of("1111");
 
     private final AktorId AKTOR_ID = AktorId.of("1234523423");
@@ -50,9 +53,16 @@ public class AktiverBrukerIntegrationTest {
         authService = mock(AuthService.class);
         behandleArbeidssokerClient = mock(BehandleArbeidssokerClient.class);
 
+        manuellStatusService = mock(ManuellStatusService.class);
+
         oppfolgingService = new OppfolgingService(
-                mock(KafkaProducerService.class), null, null, null, null, authService,
-                oppfolgingsStatusRepository, oppfolgingsPeriodeRepository, null,
+                mock(KafkaProducerService.class),
+                null,
+                null,
+                null,
+                null, authService,
+                oppfolgingsStatusRepository, oppfolgingsPeriodeRepository,
+                manuellStatusService,
                 null, new EskaleringsvarselRepository(db, transactor),
                 new KvpRepository(db, transactor), new NyeBrukereFeedRepository(db),
                 new MaalRepository(db, transactor),
@@ -69,6 +79,7 @@ public class AktiverBrukerIntegrationTest {
 
         DbTestUtils.cleanupTestDb();
         when(authService.getAktorIdOrThrow(any(Fnr.class))).thenReturn(AKTOR_ID);
+        when(manuellStatusService.hentDkifKontaktinfo(any())).thenReturn(new DkifKontaktinfo());
     }
 
     @Test

--- a/src/test/java/no/nav/veilarboppfolging/service/ManuellStatusServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/ManuellStatusServiceTest.java
@@ -15,12 +15,13 @@ import org.junit.Test;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static no.nav.veilarboppfolging.domain.KodeverkBruker.NAV;
 import static no.nav.veilarboppfolging.domain.KodeverkBruker.SYSTEM;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -101,6 +102,104 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
         when(authService.harTilgangTilEnhet(any())).thenReturn(false);
         manuellStatusService.settDigitalBruker(FNR);
     }
+
+    @Test
+    public void synkroniserManuellStatusMedDkif__skal_lage_manuell_status_hvis_reservert() {
+        DkifKontaktinfo kontaktinfo = new DkifKontaktinfo()
+                .setPersonident(FNR.get())
+                .setKanVarsles(true)
+                .setReservert(true)
+                .setEpostadresse("email")
+                .setMobiltelefonnummer("12345");
+
+        when(dkifClient.hentKontaktInfo(FNR)).thenReturn(Optional.of(kontaktinfo));
+
+        gittAktivOppfolging(AKTOR_ID);
+
+        manuellStatusService.synkroniserManuellStatusMedDkif(FNR);
+
+        List<ManuellStatus> history = manuellStatusRepository.history(AKTOR_ID);
+
+        assertEquals(1, history.size());
+    }
+
+    @Test
+    public void synkroniserManuellStatusMedDkif__skal_ikke_lage_manuell_status_hvis_ikke_reservert() {
+        DkifKontaktinfo kontaktinfo = new DkifKontaktinfo()
+                .setPersonident(FNR.get())
+                .setKanVarsles(true)
+                .setReservert(false)
+                .setEpostadresse("email")
+                .setMobiltelefonnummer("12345");
+
+        when(dkifClient.hentKontaktInfo(FNR)).thenReturn(Optional.of(kontaktinfo));
+
+        manuellStatusService.synkroniserManuellStatusMedDkif(FNR);
+
+        List<ManuellStatus> history = manuellStatusRepository.history(AKTOR_ID);
+
+        assertTrue(history.isEmpty());
+    }
+
+    @Test
+    public void settBrukerTilManuellGrunnetReservasjonIKRR__skal_lage_manuell_status() {
+        gittAktivOppfolging(AKTOR_ID);
+
+        manuellStatusService.settBrukerTilManuellGrunnetReservasjonIKRR(AKTOR_ID);
+
+        ManuellStatus manuellStatus = manuellStatusRepository.hentSisteManuellStatus(AKTOR_ID).orElseThrow();
+
+        assertTrue(manuellStatus.getId() > 0);
+        assertEquals("Brukeren er reservert i Kontakt- og reservasjonsregisteret", manuellStatus.getBegrunnelse());
+        assertEquals(SYSTEM, manuellStatus.getOpprettetAv());
+        assertNull(manuellStatus.getOpprettetAvBrukerId());
+        assertTrue(manuellStatus.getDato().isBefore(ZonedDateTime.now().plusSeconds(5)));
+    }
+
+    @Test
+    public void settBrukerTilManuellGrunnetReservasjonIKRR__skal_ikke_lage_manuell_status_hvis_allerede_manuell() {
+        gittAktivOppfolging(AKTOR_ID);
+
+        ManuellStatus manuellStatus = new ManuellStatus()
+                .setManuell(true)
+                .setAktorId(AKTOR_ID.get())
+                .setBegrunnelse("test");
+
+        manuellStatusRepository.create(manuellStatus);
+
+        manuellStatusService.settBrukerTilManuellGrunnetReservasjonIKRR(AKTOR_ID);
+
+        List<ManuellStatus> history = manuellStatusRepository.history(AKTOR_ID);
+
+        assertEquals(1, history.size());
+    }
+
+    @Test
+    public void hentDkifKontaktinfo__skal_returnere_kontaktinfo_fra_dkif() {
+        DkifKontaktinfo kontaktinfo = new DkifKontaktinfo()
+                .setPersonident(FNR.get())
+                .setKanVarsles(true)
+                .setReservert(true)
+                .setEpostadresse("email")
+                .setMobiltelefonnummer("12345");
+
+        when(dkifClient.hentKontaktInfo(FNR)).thenReturn(Optional.of(kontaktinfo));
+
+        assertEquals(kontaktinfo, manuellStatusService.hentDkifKontaktinfo(FNR));
+    }
+
+    @Test
+    public void hentDkifKontaktinfo__skal_returnere_fallback_hvis_dkif_mangler_kontaktinfo() {
+        when(dkifClient.hentKontaktInfo(FNR)).thenReturn(Optional.empty());
+
+        DkifKontaktinfo fallbackKontaktInfo = new DkifKontaktinfo()
+                .setPersonident(FNR.get())
+                .setKanVarsles(true)
+                .setReservert(false);
+
+        assertEquals(fallbackKontaktInfo, manuellStatusService.hentDkifKontaktinfo(FNR));
+    }
+
 
     private void gittAktivOppfolging(AktorId aktorId) {
         oppfolgingsStatusRepository.opprettOppfolging(aktorId);

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
@@ -362,6 +362,24 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
         assertTrue(oppfolgingService.underOppfolgingNiva3(FNR));
     }
 
+    @Test
+    public void startOppfolgingHvisIkkeAlleredeStartet__skal_opprette_ikke_opprette_manuell_status_hvis_ikke_reservert_i_krr() {
+        gittReservasjonIKrr(false);
+
+        oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(AKTOR_ID);
+
+        verify(manuellStatusService, never()).settBrukerTilManuellGrunnetReservasjonIKRR(any());
+    }
+
+    @Test
+    public void startOppfolgingHvisIkkeAlleredeStartet__skal_opprette_manuell_status_hvis_reservert_i_krr() {
+        gittReservasjonIKrr(true);
+
+        oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(AKTOR_ID);
+
+        verify(manuellStatusService, times(1)).settBrukerTilManuellGrunnetReservasjonIKRR(AKTOR_ID);
+    }
+
     private void assertUnderOppfolgingLagret(AktorId aktorId) {
         assertTrue(oppfolgingsStatusRepository.fetch(aktorId).isUnderOppfolging());
 

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
@@ -98,6 +98,8 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
         gittArenaOppfolgingStatus("", "");
 
         when(authService.getAktorIdOrThrow(FNR)).thenReturn(AKTOR_ID);
+        when(authService.getFnrOrThrow(AKTOR_ID)).thenReturn(FNR);
+
         when(arenaOppfolgingService.hentOppfolgingTilstand(FNR)).thenReturn(Optional.of(arenaOppfolgingTilstand));
         when(ytelseskontraktClient.hentYtelseskontraktListe(any())).thenReturn(mock(YtelseskontraktResponse.class));
         when(manuellStatusService.hentDkifKontaktinfo(FNR)).thenReturn(new DkifKontaktinfo());
@@ -303,7 +305,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
     }
 
     @Test
-    public void kanIkkeAvslutteNarManIkkeErUnderOppfolging() throws Exception {
+    public void kanIkkeAvslutteNarManIkkeErUnderOppfolging() {
         oppfolgingsStatusRepository.opprettOppfolging(AKTOR_ID);
         gittYtelserMedStatus();
 
@@ -313,7 +315,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
     }
 
     @Test
-    public void kanIkkeAvslutteNarManIkkeErUnderOppfolgingIArena() throws Exception {
+    public void kanIkkeAvslutteNarManIkkeErUnderOppfolgingIArena() {
         oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(AKTOR_ID);
         assertUnderOppfolgingLagret(AKTOR_ID);
 
@@ -326,7 +328,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
     }
 
     @Test
-    public void kanAvslutteMedVarselOmAktiveYtelser() throws Exception {
+    public void kanAvslutteMedVarselOmAktiveYtelser() {
         oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(AKTOR_ID);
         assertUnderOppfolgingLagret(AKTOR_ID);
 

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest2.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest2.java
@@ -1,7 +1,10 @@
 package no.nav.veilarboppfolging.service;
 
+import no.nav.common.health.HealthCheckResult;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppfolging.client.dkif.DkifClient;
+import no.nav.veilarboppfolging.client.dkif.DkifKontaktinfo;
 import no.nav.veilarboppfolging.domain.*;
 import no.nav.veilarboppfolging.repository.*;
 import no.nav.veilarboppfolging.test.DbTestUtils;
@@ -66,12 +69,24 @@ public class OppfolgingServiceTest2 extends IsolatedDatabaseTest {
 
         manuellStatusRepository = new ManuellStatusRepository(db, transactor);
 
+        DkifClient dkifClient = new DkifClient() {
+            @Override
+            public Optional<DkifKontaktinfo> hentKontaktInfo(Fnr fnr) {
+                return Optional.empty();
+            }
+
+            @Override
+            public HealthCheckResult checkHealth() {
+                return null;
+            }
+        };
+
         ManuellStatusService manuellStatusService = new ManuellStatusService(
-                mock(AuthService.class),
+                authService,
                 manuellStatusRepository,
                 null,
                 oppfolgingsStatusRepository,
-                null,
+                dkifClient,
                 null,
                 transactor
         );
@@ -84,6 +99,8 @@ public class OppfolgingServiceTest2 extends IsolatedDatabaseTest {
                 null, new EskaleringsvarselRepository(db, transactor),
                 new KvpRepository(db, transactor), new NyeBrukereFeedRepository(db), maalRepository,
                 new BrukerOppslagFlereOppfolgingAktorRepository(db), transactor);
+
+        when(authService.getFnrOrThrow(AKTOR_ID)).thenReturn(FNR);
     }
 
     @Test


### PR DESCRIPTION
For å prøve å få bedre kontroll over sideeffektene i veilarboppfolging så blir oppdatering av manuell status flyttet til eget endepunkt.