### PR TITLE
Fjernet sideeffekt for starting/avslutting av oppfølging

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/service/UnleashService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/UnleashService.java
@@ -8,19 +8,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UnleashService {
 
-    private final static String OPPDATER_OPPFOLGING_KAFKA = "veilarboppfolging.oppdater_oppfolging_kafka";
-
-    private final static String IKKE_OPPDATER_OPPFOLGING_MED_SIDEEFFEKT = "veilarboppfolging.ikke_oppdater_oppfolging_med_sideeffekt";
-
-
+    @SuppressWarnings("unused")
     private final UnleashClient unleashClient;
 
-    public boolean skalOppdaterOppfolgingMedKafka() {
-        return unleashClient.isEnabled(OPPDATER_OPPFOLGING_KAFKA);
-    }
-
-    public boolean skalIkkeOppdatereMedSideeffekt() {
-        return unleashClient.isEnabled(IKKE_OPPDATER_OPPFOLGING_MED_SIDEEFFEKT);
-    }
+    // If using unleash feature toggles add them here, dont remove this class
 
 }

--- a/src/test/java/no/nav/veilarboppfolging/service/AktiverBrukerIntegrationTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/AktiverBrukerIntegrationTest.java
@@ -59,7 +59,6 @@ public class AktiverBrukerIntegrationTest {
                 mock(KafkaProducerService.class),
                 null,
                 null,
-                null,
                 null, authService,
                 oppfolgingsStatusRepository, oppfolgingsPeriodeRepository,
                 manuellStatusService,
@@ -67,7 +66,6 @@ public class AktiverBrukerIntegrationTest {
                 new KvpRepository(db, transactor), new NyeBrukereFeedRepository(db),
                 new MaalRepository(db, transactor),
                 mock(BrukerOppslagFlereOppfolgingAktorRepository.class),
-                null,
                 transactor
         );
 

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingEndringServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingEndringServiceTest.java
@@ -29,11 +29,9 @@ public class OppfolgingEndringServiceTest {
 
     private final OppfolgingsStatusRepository oppfolgingsStatusRepository = mock(OppfolgingsStatusRepository.class);
 
-    private final UnleashService unleashService = mock(UnleashService.class);
-
     private final OppfolgingEndringService oppfolgingEndringService = new OppfolgingEndringService(
             authService, oppfolgingService, arenaOppfolgingService,
-            kvpService, metricsService, oppfolgingsStatusRepository, unleashService
+            kvpService, metricsService, oppfolgingsStatusRepository
     );
 
     @Test
@@ -57,7 +55,6 @@ public class OppfolgingEndringServiceTest {
     public void oppdaterOppfolgingMedStatusFraArena__skal_starte_oppfolging_pa_bruker_som_ikke_er_under_oppfolging_i_veilarboppfolging_men_under_oppfolging_i_arena() {
         when(authService.getAktorIdOrThrow(TEST_FNR)).thenReturn(TEST_AKTOR_ID);
         when(oppfolgingsStatusRepository.hentOppfolging(TEST_AKTOR_ID)).thenReturn(Optional.of(new OppfolgingEntity().setUnderOppfolging(false)));
-        when(unleashService.skalOppdaterOppfolgingMedKafka()).thenReturn(true);
 
         EndringPaaOppfoelgingsBrukerV2 brukverV2 = EndringPaaOppfoelgingsBrukerV2.builder()
                 .fodselsnummer(TEST_FNR.get())
@@ -72,24 +69,6 @@ public class OppfolgingEndringServiceTest {
     }
 
     @Test
-    public void oppdaterOppfolgingMedStatusFraArena__skal_ikke_starte_oppfolging_pa_bruker_hvis_toggel_er_av() {
-        when(authService.getAktorIdOrThrow(TEST_FNR)).thenReturn(TEST_AKTOR_ID);
-        when(oppfolgingsStatusRepository.hentOppfolging(TEST_AKTOR_ID)).thenReturn(Optional.of(new OppfolgingEntity().setUnderOppfolging(false)));
-        when(unleashService.skalOppdaterOppfolgingMedKafka()).thenReturn(false);
-
-        EndringPaaOppfoelgingsBrukerV2 brukverV2 = EndringPaaOppfoelgingsBrukerV2.builder()
-                .fodselsnummer(TEST_FNR.get())
-                .formidlingsgruppe(Formidlingsgruppe.ARBS)
-                .kvalifiseringsgruppe(Kvalifiseringsgruppe.VURDI)
-                .build();
-
-        oppfolgingEndringService.oppdaterOppfolgingMedStatusFraArena(brukverV2);
-
-        verify(oppfolgingService, never()).startOppfolgingHvisIkkeAlleredeStartet(any(AktorId.class));
-        verify(oppfolgingService, never()).avsluttOppfolgingForBruker(any(), any(), any());
-    }
-
-    @Test
     public void oppdaterOppfolgingMedStatusFraArena__skal_avslutte_oppfolging_pa_bruker_som_er_under_oppfolging_i_veilarboppfolging_men_ikke_under_oppfolging_i_arena() {
         var arenaTilstand = new ArenaOppfolgingTilstand();
         arenaTilstand.setKanEnkeltReaktiveres(false);
@@ -98,8 +77,6 @@ public class OppfolgingEndringServiceTest {
         when(oppfolgingsStatusRepository.hentOppfolging(TEST_AKTOR_ID)).thenReturn(Optional.of(new OppfolgingEntity().setUnderOppfolging(true)));
         when(arenaOppfolgingService.hentOppfolgingTilstandDirekteFraArena(TEST_FNR)).thenReturn(Optional.of(arenaTilstand));
         when(kvpService.erUnderKvp(TEST_AKTOR_ID)).thenReturn(false);
-        when(unleashService.skalOppdaterOppfolgingMedKafka()).thenReturn(true);
-
 
         EndringPaaOppfoelgingsBrukerV2 brukverV2 = EndringPaaOppfoelgingsBrukerV2.builder()
                 .fodselsnummer(TEST_FNR.get())
@@ -117,32 +94,6 @@ public class OppfolgingEndringServiceTest {
                 );
 
         verify(metricsService, times(1)).rapporterAutomatiskAvslutningAvOppfolging(true);
-    }
-
-    @Test
-    public void oppdaterOppfolgingMedStatusFraArena__skal_ikke_avslutte_oppfolging_pa_bruker_hvis_toggel_er_av() {
-        var arenaTilstand = new ArenaOppfolgingTilstand();
-        arenaTilstand.setKanEnkeltReaktiveres(false);
-
-        when(authService.getAktorIdOrThrow(TEST_FNR)).thenReturn(TEST_AKTOR_ID);
-        when(oppfolgingsStatusRepository.hentOppfolging(TEST_AKTOR_ID)).thenReturn(Optional.of(new OppfolgingEntity().setUnderOppfolging(true)));
-        when(arenaOppfolgingService.hentOppfolgingTilstandDirekteFraArena(TEST_FNR)).thenReturn(Optional.of(arenaTilstand));
-        when(kvpService.erUnderKvp(TEST_AKTOR_ID)).thenReturn(false);
-        when(unleashService.skalOppdaterOppfolgingMedKafka()).thenReturn(false);
-
-
-        EndringPaaOppfoelgingsBrukerV2 brukverV2 = EndringPaaOppfoelgingsBrukerV2.builder()
-                .fodselsnummer(TEST_FNR.get())
-                .formidlingsgruppe(Formidlingsgruppe.ISERV)
-                .kvalifiseringsgruppe(Kvalifiseringsgruppe.VURDI)
-                .build();
-
-        oppfolgingEndringService.oppdaterOppfolgingMedStatusFraArena(brukverV2);
-
-
-        verify(oppfolgingService, never()).startOppfolgingHvisIkkeAlleredeStartet(any(AktorId.class));
-        verify(oppfolgingService, never()).avsluttOppfolgingForBruker(any(), any(), any());
-        verify(metricsService, never()).rapporterAutomatiskAvslutningAvOppfolging(true);
     }
 
     @Test

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest2.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest2.java
@@ -99,12 +99,12 @@ public class OppfolgingServiceTest2 extends IsolatedDatabaseTest {
 
         oppfolgingService = new OppfolgingService(
                 mock(KafkaProducerService.class), null,
-                null, null, null, authService,
+                null, null, authService,
                 oppfolgingsStatusRepository, oppfolgingsPeriodeRepository,
                 manuellStatusService,
                 null, new EskaleringsvarselRepository(db, transactor),
                 new KvpRepository(db, transactor), new NyeBrukereFeedRepository(db), maalRepository,
-                new BrukerOppslagFlereOppfolgingAktorRepository(db), null, transactor);
+                new BrukerOppslagFlereOppfolgingAktorRepository(db), transactor);
 
         when(authService.getFnrOrThrow(AKTOR_ID)).thenReturn(FNR);
     }


### PR DESCRIPTION
Automatisk oppstart/avslutting av oppfølging basert på status fra Arena blir gjort i kafka, så vi trenger ikke lenger og ha den samme logikken i sideeffekten i tillegg.