### PR TITLE
Bugfix manuell status, hent manuell status koblet via OPPFOLGINGSSTATUS-tabellen

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/repository/ManuellStatusRepository.java
+++ b/src/main/java/no/nav/veilarboppfolging/repository/ManuellStatusRepository.java
@@ -55,11 +55,6 @@ public class ManuellStatusRepository {
         );
     }
 
-    public Optional<ManuellStatusEntity> hentSisteManuellStatus(AktorId aktorId) {
-        String sql = "SELECT * FROM MANUELL_STATUS WHERE aktor_id = ? ORDER BY OPPRETTET_DATO DESC FETCH NEXT 1 ROWS ONLY";
-        return queryForNullableObject(db, sql, ManuellStatusRepository::map, aktorId.get());
-    }
-
     @SneakyThrows
     public static ManuellStatusEntity map(ResultSet result, int row) {
         return new ManuellStatusEntity()

--- a/src/main/java/no/nav/veilarboppfolging/repository/entity/OppfolgingEntity.java
+++ b/src/main/java/no/nav/veilarboppfolging/repository/entity/OppfolgingEntity.java
@@ -15,7 +15,7 @@ public class OppfolgingEntity {
     private String aktorId;
     private String veilederId;
     private boolean underOppfolging;
-    private long gjeldendeManuellStatusId;
+    private Long gjeldendeManuellStatusId;
     private long gjeldendeEskaleringsvarselId;
     private long gjeldendeMaalId;
     private long gjeldendeKvpId;

--- a/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
@@ -301,10 +301,8 @@ public class OppfolgingService {
             );
         }
 
-        if (oppfolgingEntity.getGjeldendeManuellStatusId() != 0) {
-            Optional<ManuellStatusEntity> manuellStatus = manuellStatusService.hentManuellStatus(oppfolgingEntity.getGjeldendeManuellStatusId());
-            manuellStatus.ifPresent(oppfolging::setGjeldendeManuellStatus);
-        }
+        Optional<ManuellStatusEntity> manuellStatus = manuellStatusService.hentManuellStatus(aktorId);
+        manuellStatus.ifPresent(oppfolging::setGjeldendeManuellStatus);
 
         List<KvpPeriodeEntity> kvpPerioder = kvpRepository.hentKvpHistorikk(aktorId);
         oppfolging.setOppfolgingsperioder(populerKvpPerioder(oppfolgingsPeriodeRepository.hentOppfolgingsperioder(AktorId.of(oppfolgingEntity.getAktorId())), kvpPerioder));

--- a/src/test/java/no/nav/veilarboppfolging/repository/ManuellStatusRepositoryTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/repository/ManuellStatusRepositoryTest.java
@@ -9,7 +9,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.ZonedDateTime;
-import java.util.Optional;
 
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static no.nav.veilarboppfolging.test.TestData.TEST_AKTOR_ID;
@@ -74,52 +73,6 @@ public class ManuellStatusRepositoryTest extends IsolatedDatabaseTest {
 
         var statuser = manuellStatusRepository.history(TEST_AKTOR_ID);
         assertEquals(2, statuser.size());
-    }
-
-    @Test
-    public void hentSisteManuellStatus__should_return_empty_if_no_status() {
-        assertTrue(manuellStatusRepository.hentSisteManuellStatus(TEST_AKTOR_ID).isEmpty());
-    }
-
-    @Test
-    public void hentSisteManuellStatus__should_return_status() {
-        ManuellStatusEntity manuellStatus = createManuellStatus(TEST_AKTOR_ID);
-
-        oppfolgingsStatusRepository.opprettOppfolging(TEST_AKTOR_ID);
-
-        manuellStatusRepository.create(manuellStatus);
-
-        Optional<ManuellStatusEntity> maybeManuellStatus = manuellStatusRepository.hentSisteManuellStatus(TEST_AKTOR_ID);
-
-        assertTrue(maybeManuellStatus.isPresent());
-        manuellStatus.setDato(manuellStatus.getDato().truncatedTo(MILLIS));
-        ManuellStatusEntity gotten = maybeManuellStatus.get();
-        gotten.setDato(gotten.getDato().truncatedTo(MILLIS));
-        assertEquals(manuellStatus, maybeManuellStatus.get());
-    }
-
-    @Test
-    public void hentSisteManuellStatus__should_return_last_status() {
-        ManuellStatusEntity manuellStatus1 = createManuellStatus(TEST_AKTOR_ID)
-                .setManuell(false)
-                .setDato(ZonedDateTime.now().minusSeconds(10));
-
-        ManuellStatusEntity manuellStatus2 = createManuellStatus(TEST_AKTOR_ID)
-                .setManuell(true)
-                .setDato(ZonedDateTime.now());
-
-        oppfolgingsStatusRepository.opprettOppfolging(TEST_AKTOR_ID);
-
-        manuellStatusRepository.create(manuellStatus1);
-        manuellStatusRepository.create(manuellStatus2);
-
-        Optional<ManuellStatusEntity> maybeManuellStatus = manuellStatusRepository.hentSisteManuellStatus(TEST_AKTOR_ID);
-
-        assertTrue(maybeManuellStatus.isPresent());
-        manuellStatus2.setDato(manuellStatus2.getDato().truncatedTo(MILLIS));
-        ManuellStatusEntity gotten = maybeManuellStatus.get();
-        gotten.setDato(gotten.getDato().truncatedTo(MILLIS));
-        assertEquals(manuellStatus2, gotten);
     }
 
     private ManuellStatusEntity createManuellStatus(AktorId aktorId) {

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest2.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest2.java
@@ -92,6 +92,7 @@ public class OppfolgingServiceTest2 extends IsolatedDatabaseTest {
                 manuellStatusRepository,
                 null,
                 oppfolgingServiceMock,
+                oppfolgingsStatusRepository,
                 dkifClient,
                 null,
                 transactor


### PR DESCRIPTION
Siste manuell status til bruker ble brukt, selv om den ikke var koblet via OPPFOLGINGSSTATUS-tabellen. Dermed kunne gamle/ikke gjeldende manuell statuser bli brukt.