### PR TITLE
Fjernet ABAC sjekk for systembruker endepunkter

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -64,6 +64,8 @@ spec:
   env:
     - name: MODIABLOGIN_OPENAM_CLIENT_ID
       value: "modialogin-q1"
+    - name: VEILARBREGISTRERING_CLIENT_ID
+      value: 687bb3b0-a83c-47b7-9562-c6f9fedcc898
 
     # producer topics
     - name: ENDRING_PAA_AVSLUTT_OPPFOLGING_TOPIC

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -63,6 +63,8 @@ spec:
   env:
     - name: MODIABLOGIN_OPENAM_CLIENT_ID
       value: "modialogin-p"
+    - name: VEILARBREGISTRERING_CLIENT_ID
+      value: b898d7c6-0160-4dca-867e-873a4bd85d25
 
     # producer topics
     - name: ENDRING_PAA_AVSLUTT_OPPFOLGING_TOPIC

--- a/src/main/java/no/nav/veilarboppfolging/config/EnvironmentProperties.java
+++ b/src/main/java/no/nav/veilarboppfolging/config/EnvironmentProperties.java
@@ -9,6 +9,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "app.env")
 public class EnvironmentProperties {
 
+    private String veilarbregistreringClientId;
+
     private String openAmDiscoveryUrl;
 
     private String veilarbloginOpenAmClientId;

--- a/src/main/java/no/nav/veilarboppfolging/controller/SystemOppfolgingController.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/SystemOppfolgingController.java
@@ -3,6 +3,7 @@ package no.nav.veilarboppfolging.controller;
 import lombok.RequiredArgsConstructor;
 import no.nav.common.types.identer.Fnr;
 import no.nav.veilarboppfolging.client.behandle_arbeidssoker.ArenaFeilException;
+import no.nav.veilarboppfolging.config.EnvironmentProperties;
 import no.nav.veilarboppfolging.controller.request.AktiverArbeidssokerData;
 import no.nav.veilarboppfolging.controller.request.ReaktiverBrukerRequest;
 import no.nav.veilarboppfolging.controller.request.SykmeldtBrukerType;
@@ -26,11 +27,14 @@ public class SystemOppfolgingController {
 
     private final AktiverBrukerService aktiverBrukerService;
 
+    private final EnvironmentProperties environmentProperties;
+
     // Veilarbregistrering forventer 204, som forsåvidt er riktig status for disse endepunktene
 
     @PostMapping("/aktiverbruker")
     public ResponseEntity aktiverBruker(@RequestBody AktiverArbeidssokerData aktiverArbeidssokerData) {
         authService.skalVereSystemBruker();
+        authService.sjekkAtSystembrukerErWhitelistet(environmentProperties.getVeilarbregistreringClientId());
 
         AktiverArbeidssokerData.Fnr requestFnr = ofNullable(aktiverArbeidssokerData.getFnr())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "FNR mangler"));
@@ -52,6 +56,7 @@ public class SystemOppfolgingController {
     @PostMapping("/reaktiverbruker")
     public ResponseEntity reaktiverBruker(@RequestBody ReaktiverBrukerRequest request) {
         authService.skalVereSystemBruker();
+        authService.sjekkAtSystembrukerErWhitelistet(environmentProperties.getVeilarbregistreringClientId());
 
         try {
             aktiverBrukerService.reaktiverBruker(request.getFnr());
@@ -68,6 +73,7 @@ public class SystemOppfolgingController {
     @PostMapping("/aktiverSykmeldt")
     public ResponseEntity aktiverSykmeldt(@RequestBody SykmeldtBrukerType sykmeldtBrukerType, @RequestParam Fnr fnr) {
         authService.skalVereSystemBruker();
+        authService.sjekkAtSystembrukerErWhitelistet(environmentProperties.getVeilarbregistreringClientId());
 
         aktiverBrukerService.aktiverSykmeldt(fnr, sykmeldtBrukerType);
         return ResponseEntity.status(204).build();

--- a/src/main/java/no/nav/veilarboppfolging/controller/SystemOppfolgingController.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/SystemOppfolgingController.java
@@ -37,8 +37,6 @@ public class SystemOppfolgingController {
 
         Fnr fnr = Fnr.of(requestFnr.getFnr());
 
-        authService.sjekkLesetilgangMedFnr(fnr);
-
         try {
             aktiverBrukerService.aktiverBruker(fnr, aktiverArbeidssokerData.getInnsatsgruppe());
         } catch (ArenaFeilException exception) {
@@ -54,7 +52,6 @@ public class SystemOppfolgingController {
     @PostMapping("/reaktiverbruker")
     public ResponseEntity reaktiverBruker(@RequestBody ReaktiverBrukerRequest request) {
         authService.skalVereSystemBruker();
-        authService.sjekkLesetilgangMedFnr(request.getFnr());
 
         try {
             aktiverBrukerService.reaktiverBruker(request.getFnr());
@@ -71,7 +68,7 @@ public class SystemOppfolgingController {
     @PostMapping("/aktiverSykmeldt")
     public ResponseEntity aktiverSykmeldt(@RequestBody SykmeldtBrukerType sykmeldtBrukerType, @RequestParam Fnr fnr) {
         authService.skalVereSystemBruker();
-        authService.sjekkLesetilgangMedFnr(fnr);
+
         aktiverBrukerService.aktiverSykmeldt(fnr, sykmeldtBrukerType);
         return ResponseEntity.status(204).build();
     }

--- a/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
@@ -1,5 +1,6 @@
 package no.nav.veilarboppfolging.service;
 
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.abac.AbacUtils;
 import no.nav.common.abac.Pep;
@@ -24,6 +25,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static java.lang.String.format;
@@ -225,5 +227,16 @@ public class AuthService {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
         return getInnloggetBrukerIdent();
+    }
+
+    @SneakyThrows
+    public void sjekkAtSystembrukerErWhitelistet(String... clientIdWhitelist) {
+        String requestingAppClientId = authContextHolder.requireIdTokenClaims().getStringClaim("azp");
+        boolean isWhitelisted = Arrays.asList(clientIdWhitelist).contains(requestingAppClientId);
+
+        if (!isWhitelisted) {
+            log.error("Systembruker {} er ikke whitelistet", requestingAppClientId);
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,6 +49,8 @@ app.env.loginserviceIdportenDiscoveryUrl=${LOGINSERVICE_IDPORTEN_DISCOVERY_URL:n
 app.env.naisAadDiscoveryUrl=${AZURE_APP_WELL_KNOWN_URL:null}
 app.env.naisAadClientId=${AZURE_APP_CLIENT_ID:null}
 
+app.env.veilarbregistreringClientId=${VEILARBREGISTRERING_CLIENT_ID:null}
+
 app.kafka.brokersUrl=${KAFKA_BROKERS_URL:null}
 app.kafka.endringPaaOppfolgingBrukerTopic=pto.endring-paa-oppfolgingsbruker-v2
 app.kafka.endringPaaAvsluttOppfolgingTopic=${ENDRING_PAA_AVSLUTT_OPPFOLGING_TOPIC:null}

--- a/src/test/java/no/nav/veilarboppfolging/controller/SystemOppfolgingControllerTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/SystemOppfolgingControllerTest.java
@@ -5,6 +5,7 @@ import no.nav.common.auth.context.UserRole;
 import no.nav.common.test.auth.AuthTestUtils;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppfolging.config.EnvironmentProperties;
 import no.nav.veilarboppfolging.controller.request.AktiverArbeidssokerData;
 import no.nav.veilarboppfolging.controller.request.ReaktiverBrukerRequest;
 import no.nav.veilarboppfolging.controller.request.SykmeldtBrukerType;
@@ -24,7 +25,13 @@ public class SystemOppfolgingControllerTest {
 
     private AktiverBrukerService aktiverBrukerService = mock(AktiverBrukerService.class);
 
-    private SystemOppfolgingController systemOppfolgingController = new SystemOppfolgingController(authService, aktiverBrukerService);
+    private EnvironmentProperties environmentProperties = mock(EnvironmentProperties.class);
+
+    private SystemOppfolgingController systemOppfolgingController = new SystemOppfolgingController(
+            authService,
+            aktiverBrukerService,
+            environmentProperties
+    );
 
     @Test
     public void aktiverBruker() {

--- a/src/test/java/no/nav/veilarboppfolging/service/AuthServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package no.nav.veilarboppfolging.service;
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import no.nav.common.abac.Pep;
 import no.nav.common.auth.context.AuthContextHolder;
 import no.nav.common.auth.context.UserRole;
@@ -54,6 +55,28 @@ public class AuthServiceTest {
         when(authContextHolder.getRole()).thenReturn(Optional.empty());
         when(authContextHolder.requireRole()).thenCallRealMethod();
         assertThrows(IllegalStateException.class, () -> authService.skalVereEnAv(List.of(UserRole.INTERN)));
+    }
+
+    @Test
+    public void sjekkAtSystembrukerErWhitelistet__skal_ikke_kaste_exception_hvis_whitelistet() {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .claim("azp", "test")
+                .build();
+
+        when(authContextHolder.requireIdTokenClaims()).thenReturn(claims);
+
+        assertDoesNotThrow(() -> authService.sjekkAtSystembrukerErWhitelistet("test"));
+    }
+
+    @Test
+    public void sjekkAtSystembrukerErWhitelistet__skal_kaste_exception_hvis_ikke_whitelistet() {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .claim("azp", "test")
+                .build();
+
+        when(authContextHolder.requireIdTokenClaims()).thenReturn(claims);
+
+        assertThrows(ResponseStatusException.class, () -> authService.sjekkAtSystembrukerErWhitelistet("some-id"));
     }
 
 }


### PR DESCRIPTION
Veilarbregistrering kaller disse endepunktene med AAD som vi ikke kan gjøre ABAC sjekker på.
Endepunktene er beskyttet slik at kun systembrukere kan kalle de, så det burde ikke være nødvendig å gjøre tilgangssjekk med ABAC.