### PR TITLE
Endepunkt: hente ut under oppfølging på en bruker som systembruker

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/controller/SystemOppfolgingController.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/SystemOppfolgingController.java
@@ -10,6 +10,7 @@ import no.nav.veilarboppfolging.controller.request.SykmeldtBrukerType;
 import no.nav.veilarboppfolging.controller.response.ArenaFeilDTO;
 import no.nav.veilarboppfolging.service.AktiverBrukerService;
 import no.nav.veilarboppfolging.service.AuthService;
+import no.nav.veilarboppfolging.service.OppfolgingService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -28,6 +29,8 @@ public class SystemOppfolgingController {
     private final AktiverBrukerService aktiverBrukerService;
 
     private final EnvironmentProperties environmentProperties;
+
+    private final OppfolgingService oppfolgingService;
 
     // Veilarbregistrering forventer 204, som forsåvidt er riktig status for disse endepunktene
 
@@ -77,6 +80,12 @@ public class SystemOppfolgingController {
 
         aktiverBrukerService.aktiverSykmeldt(fnr, sykmeldtBrukerType);
         return ResponseEntity.status(204).build();
+    }
+
+    @GetMapping("/underOppfolgingSystem/")
+    public boolean erBrukerUnderOppfolging(@RequestParam(value = "fnr") Fnr fnr) {
+        authService.skalVereSystemBruker();
+        return oppfolgingService.erUnderOppfolging(fnr);
     }
 
 }

--- a/src/test/java/no/nav/veilarboppfolging/controller/SystemOppfolgingControllerTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/SystemOppfolgingControllerTest.java
@@ -11,6 +11,7 @@ import no.nav.veilarboppfolging.controller.request.ReaktiverBrukerRequest;
 import no.nav.veilarboppfolging.controller.request.SykmeldtBrukerType;
 import no.nav.veilarboppfolging.service.AktiverBrukerService;
 import no.nav.veilarboppfolging.service.AuthService;
+import no.nav.veilarboppfolging.service.OppfolgingService;
 import org.junit.Test;
 
 import static org.mockito.Mockito.*;
@@ -27,10 +28,13 @@ public class SystemOppfolgingControllerTest {
 
     private EnvironmentProperties environmentProperties = mock(EnvironmentProperties.class);
 
+    private OppfolgingService oppfolgingService = mock(OppfolgingService.class);
+
     private SystemOppfolgingController systemOppfolgingController = new SystemOppfolgingController(
             authService,
             aktiverBrukerService,
-            environmentProperties
+            environmentProperties,
+            oppfolgingService
     );
 
     @Test


### PR DESCRIPTION
Behov: veilarbportefolje trenger dette endepunktet for å kunne vite om kafka meldinger på endring av manuell status har kommet før meldingen om oppfølgingstartet