### PR TITLE
Add config for accepting tokens issued as part of AAD OBO flow

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/config/FilterConfig.java
+++ b/src/main/java/no/nav/veilarboppfolging/config/FilterConfig.java
@@ -67,6 +67,15 @@ public class FilterConfig {
                 .withUserRole(UserRole.INTERN);
     }
 
+    private OidcAuthenticatorConfig createAadOboConfig(EnvironmentProperties properties) {
+        String discoveryUrl = properties.getNaisAadDiscoveryUrl();
+        String clientId = properties.getNaisAadClientId();
+        return new OidcAuthenticatorConfig()
+                .withDiscoveryUrl(discoveryUrl)
+                .withClientId(clientId)
+                .withUserRole(UserRole.INTERN);
+    }
+
     private OidcAuthenticatorConfig loginserviceIdportenConfig(EnvironmentProperties properties) {
         return new OidcAuthenticatorConfig()
                 .withDiscoveryUrl(properties.getLoginserviceIdportenDiscoveryUrl())
@@ -104,7 +113,8 @@ public class FilterConfig {
                         loginserviceIdportenConfig(properties),
                         openAmStsAuthConfig(properties),
                         naisStsAuthConfig(properties),
-                        naisAzureAdConfig(properties)
+                        naisAzureAdConfig(properties),
+                        createAadOboConfig(properties)
                 )
         );
 


### PR DESCRIPTION
Veilederdelen av arbeidssøkerregistrering er i ferd med å ta i bruk wonderwall og obo flyt for kommunikasjonen mellom frontend og bakover. Endepunktet GET /oppfolging avhenger enn så lenge av brukerkontekst, og denne configen skulle sørge for at veilarboppfølging kan autentisere AAD tokens scopet "riktig".