### PR TITLE
Fjern utgående regel for veilarbarena

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -59,11 +59,6 @@ spec:
           cluster: dev-gcp
         - application: paw-proxy
           namespace: paw
-    outbound:
-      rules:
-        - application: veilarbarena
-          namespace: pto
-          cluster: dev-fss
   vault:
     enabled: true
     paths:

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -57,11 +57,6 @@ spec:
           cluster: prod-gcp
         - application: paw-proxy
           namespace: paw
-    outbound:
-      rules:
-        - application: veilarbarena
-          namespace: pto
-          cluster: prod-fss
   vault:
     enabled: true
     paths:


### PR DESCRIPTION
Skal ikke være nødvendig for å veksle AAD OBO-token.