### PR TITLE
Legger til midlertidig AuthInfoFilter

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/config/AuthInfoFilter.java
+++ b/src/main/java/no/nav/veilarboppfolging/config/AuthInfoFilter.java
@@ -1,0 +1,64 @@
+package no.nav.veilarboppfolging.config;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import lombok.RequiredArgsConstructor;
+import no.nav.common.auth.context.AuthContextHolder;
+import no.nav.common.auth.context.AuthContextHolderThreadLocal;
+import no.nav.common.auth.context.UserRole;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.List;
+
+import static no.nav.common.log.LogFilter.CONSUMER_ID_HEADER_NAME;
+
+@RequiredArgsConstructor
+public class AuthInfoFilter implements Filter {
+
+    private final MeterRegistry meterRegistry;
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse response, FilterChain chain) {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        AuthContextHolder authContextHolder = AuthContextHolderThreadLocal.instance();
+
+        String consumerId = request.getHeader(CONSUMER_ID_HEADER_NAME);
+        if (consumerId == null) {
+            consumerId = "UKJENT";
+        }
+
+        String userRole = authContextHolder.getRole().map(UserRole::name).orElse("UKJENT");
+
+        String tokenIssuer = authContextHolder.getIdTokenClaims().map(JWTClaimsSet::getIssuer).orElse("");
+
+        String tokenType;
+        if (tokenIssuer.contains("microsoftonline.com")) {
+            tokenType = "AAD";
+        } else if (tokenIssuer.contains("difi.no")) {
+            tokenType = "IDPORTEN";
+        } else if (tokenIssuer.contains("tokendings")) {
+            tokenType = "TOKENX";
+        } else if (tokenIssuer.contains("isso")) {
+            tokenType = "OPENAM";
+        } else if (tokenIssuer.contains("security-token-service")) {
+            tokenType = "STS";
+        }  else {
+            tokenType = "UKJENT";
+        }
+
+        meterRegistry.counter(
+                "auth_info_token_type",
+                List.of(
+                        Tag.of("type", tokenType),
+                        Tag.of("consumer_id", consumerId),
+                        Tag.of("user_role", userRole)
+                )
+        );
+    }
+}

--- a/src/main/java/no/nav/veilarboppfolging/config/FilterConfig.java
+++ b/src/main/java/no/nav/veilarboppfolging/config/FilterConfig.java
@@ -1,5 +1,6 @@
 package no.nav.veilarboppfolging.config;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import no.nav.common.auth.context.UserRole;
 import no.nav.common.auth.oidc.filter.AzureAdUserRoleResolver;
 import no.nav.common.auth.oidc.filter.OidcAuthenticationFilter;
@@ -140,4 +141,12 @@ public class FilterConfig {
         return registration;
     }
 
+    @Bean
+    public FilterRegistrationBean<AuthInfoFilter> authInfoFilterRegistrationBean(MeterRegistry meterRegistry) {
+        FilterRegistrationBean<AuthInfoFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new AuthInfoFilter(meterRegistry));
+        registration.setOrder(6);
+        registration.addUrlPatterns("/api/*");
+        return registration;
+    }
 }


### PR DESCRIPTION
For å identifisere hvilke token typer som brukes. Formål er hovedsaklig å kartlegge bruk av OpenAM og STS. Filteret kan eventuelt fjernes etter at støtte for disse er fjernet. AuthInfoFilter belager seg på info fra AuthContextHolder, så filteret må være etter OidcAuthenticationFilter i rekkefølgen filterene registreres.