### PR TITLE
Auth annotation with support for eksterne

### DIFF
--- a/.github/workflows/deploy-feature.yml
+++ b/.github/workflows/deploy-feature.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Build maven artifacts
-        run: mvn -B package
+        run: mvn -B package -DskipTests
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <common.version>2.2022.11.16_08.36-35c94368bc44</common.version>
+        <common.version>2.2023.01.10_13.49-81ddc732df3a</common.version>
         <tjenestespesifikasjoner.version>1.2019.09.25-00.21-49b69f0625e0</tjenestespesifikasjoner.version>
         <testcontainers.version>1.16.3</testcontainers.version>
     </properties>
@@ -186,6 +186,11 @@
         <dependency>
             <groupId>no.nav.common</groupId>
             <artifactId>auth</artifactId>
+            <version>${common.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.common</groupId>
+            <artifactId>audit-log</artifactId>
             <version>${common.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/no/nav/veilarboppfolging/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/veilarboppfolging/config/ApplicationConfig.java
@@ -8,6 +8,8 @@ import no.nav.common.abac.VeilarbPepFactory;
 import no.nav.common.abac.audit.AuditLogFilterUtils;
 import no.nav.common.abac.audit.SpringAuditRequestInfoSupplier;
 import no.nav.common.abac.constants.NavAttributter;
+import no.nav.common.audit_log.log.AuditLogger;
+import no.nav.common.audit_log.log.AuditLoggerImpl;
 import no.nav.common.auth.context.AuthContextHolder;
 import no.nav.common.auth.context.AuthContextHolderThreadLocal;
 import no.nav.common.cxf.StsConfig;
@@ -105,6 +107,11 @@ public class ApplicationConfig {
                 serviceUserCredentials.password, new SpringAuditRequestInfoSupplier(),
                 AuditLogFilterUtils.not(anyResourceAttributeFilter(NavAttributter.RESOURCE_VEILARB_ENHET_EIENDEL::equals))
         );
+    }
+
+    @Bean
+    AuditLogger auditLogger() {
+        return new AuditLoggerImpl();
     }
 
 }

--- a/src/main/java/no/nav/veilarboppfolging/controller/KvpController.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/KvpController.java
@@ -1,8 +1,9 @@
 package no.nav.veilarboppfolging.controller;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import no.nav.common.auth.context.AuthContextHolder;
 import no.nav.common.types.identer.AktorId;
@@ -37,16 +38,15 @@ public class KvpController {
 
 
     @GetMapping("/{aktorId}/currentStatus")
-    @ApiOperation(
-            value = "Extract KVP status for an actor",
-            notes = "This API endpoint is only available for system users"
+    @Operation(
+            summary = "Extract KVP status for an actor. This API endpoint is only available for system users",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Actor is currently in a KVP period.", content = @Content(schema = @Schema(implementation = KvpDTO.class))),
+                    @ApiResponse(responseCode = "204", description = "Actor is currently not in a KVP period."),
+                    @ApiResponse(responseCode = "403", description = "The API endpoint is requested by a user which is not in the allowed users list."),
+                    @ApiResponse(responseCode = "500", description = "There is a server-side bug which should be fixed.")
+            }
     )
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "Actor is currently in a KVP period.", response = KvpDTO.class),
-            @ApiResponse(code = 204, message = "Actor is currently not in a KVP period."),
-            @ApiResponse(code = 403, message = "The API endpoint is requested by a user which is not in the allowed users list."),
-            @ApiResponse(code = 500, message = "There is a server-side bug which should be fixed.")
-    })
     public ResponseEntity<KvpDTO> getKvpStatus(@PathVariable("aktorId") AktorId aktorId) {
         // KVP information is only available to certain system users. We trust these users here,
         // so that we can avoid doing an ABAC query on each request.

--- a/src/main/java/no/nav/veilarboppfolging/controller/v2/KvpV2Controller.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/v2/KvpV2Controller.java
@@ -1,7 +1,9 @@
 package no.nav.veilarboppfolging.controller.v2;
 
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import no.nav.common.auth.context.AuthContextHolder;
 import no.nav.common.types.identer.AktorId;
@@ -34,10 +36,10 @@ public class KvpV2Controller {
     private final AuthContextHolder authContextHolder;
 
     @GetMapping
-    @ApiResponses({
-            @ApiResponse(code = 200, message = "Actor is currently in a KVP period.", response = KvpDTO.class),
-            @ApiResponse(code = 204, message = "Actor is currently not in a KVP period."),
-            @ApiResponse(code = 403, message = "The API endpoint is requested by a user which is not in the allowed users list.")
+    @Operation(responses = {
+            @ApiResponse(responseCode = "200", description = "Actor is currently in a KVP period.", content = @Content(schema = @Schema(implementation = KvpDTO.class))),
+            @ApiResponse(responseCode = "204", description = "Actor is currently not in a KVP period."),
+            @ApiResponse(responseCode = "403", description = "The API endpoint is requested by a user which is not in the allowed users list.")
     })
     public ResponseEntity<KvpDTO> getKvpStatus(@RequestParam("aktorId") AktorId aktorId) {
         // KVP information is only available to certain system users. We trust these users here,

--- a/src/main/java/no/nav/veilarboppfolging/controller/v2/OppfolgingV2Controller.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/v2/OppfolgingV2Controller.java
@@ -33,7 +33,7 @@ public class OppfolgingV2Controller {
 
     private final AuthService authService;
 
-    @AuthorizeFnr(allowlist = {"veilarbvedtaksstotte", "veilarbdialog", "veilarbaktivitet"})
+    @AuthorizeFnr(allowlist = {"veilarbvedtaksstotte", "veilarbdialog", "veilarbaktivitet", "veilarbregistrering"})
     @GetMapping(params = "fnr")
     public UnderOppfolgingV2Response underOppfolging(@RequestParam(value = "fnr") Fnr fnr) {
         return new UnderOppfolgingV2Response(oppfolgingService.erUnderOppfolging(fnr));

--- a/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
@@ -151,7 +151,13 @@ public class AuthService {
     }
 
     public void sjekkLesetilgangMedFnr(Fnr fnr) {
-        sjekkLesetilgangMedAktorId(getAktorIdOrThrow(fnr));
+        if (authContextHolder.erEksternBruker()) {
+            if (!harEksternBrukerTilgang(fnr)) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Ekstern bruker har ikke tilgang på andre brukere enn seg selv");
+            }
+        } else {
+            sjekkLesetilgangMedAktorId(getAktorIdOrThrow(fnr));
+        }
     }
 
     public void sjekkLesetilgangMedAktorId(AktorId aktorId) {
@@ -306,6 +312,10 @@ public class AuthService {
         return empty();
     }
 
+
+    public void sjekkAtApplikasjonErIAllowList(String[] allowlist) {
+        sjekkAtApplikasjonErIAllowList(List.of(allowlist));
+    }
     @SneakyThrows
     public void sjekkAtApplikasjonErIAllowList(List<String> allowlist) {
         String appname = hentApplikasjonFraContext();

--- a/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
@@ -108,7 +108,7 @@ public class AuthService {
             .severity(CefMessageSeverity.INFO)
             .name("veilarboppfolging-audit-log")
             .destinationUserId(fnr.get())
-            .extension("msg", "Ekstern bruker har gjort oppslag på bruker")
+            .extension("msg", isAllowed ? "Ekstern bruker har gjort oppslag på seg selv" : "Ekstern bruker ble nektet innsyn")
             .build());
         return isAllowed;
     }

--- a/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
@@ -151,7 +151,7 @@ public class AuthService {
     }
 
     public void sjekkLesetilgangMedFnr(Fnr fnr) {
-        if (authContextHolder.erEksternBruker()) {
+        if (erEksternBruker()) {
             if (!harEksternBrukerTilgang(fnr)) {
                 throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Ekstern bruker har ikke tilgang på andre brukere enn seg selv");
             }

--- a/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
@@ -345,7 +345,7 @@ public class AuthService {
         } else if (isTokenX(maybeClaims)) {
             return maybeClaims.flatMap(claims -> getStringClaimOrEmpty(claims, "client_id"));
         } else {
-            return Optional.empty();
+            return authContextHolder.getSubject();
         }
     }
 

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizationAnnotationHandler.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizationAnnotationHandler.java
@@ -34,25 +34,27 @@ public class AuthorizationAnnotationHandler {
             var allowlist = ((AuthorizeFnr) annotation).allowlist();
             handleAuthorizeFnr(fnr, allowlist);
         } else if (annotation instanceof AuthorizeAktorId) {
-            var allowlist = ((AuthorizeFnr) annotation).allowlist();
+            var allowlist = ((AuthorizeAktorId) annotation).allowlist();
             var aktorId = AktorId.of(getAktorId(request));
             handleAuthorizeAktorId(aktorId, allowlist);
         }
     }
 
     private void handleAuthorizeFnr(Fnr fnr, String[] allowlist) {
-        authService.sjekkAtApplikasjonErIAllowList(allowlist);
         if (authService.erEksternBruker()) {
             authService.harEksternBrukerTilgang(fnr);
+        } else if (authService.erSystemBrukerFraAzureAd()) {
+            authService.sjekkAtApplikasjonErIAllowList(allowlist);
         } else if (authService.erInternBruker()) {
             authService.sjekkLesetilgangMedFnr(fnr);
         }
     }
 
     private void handleAuthorizeAktorId(AktorId aktorId, String[] allowlist) {
-        authService.sjekkAtApplikasjonErIAllowList(allowlist);
         if (authService.erInternBruker()) {
             authService.sjekkLesetilgangMedAktorId(aktorId);
+        } else if (authService.erSystemBrukerFraAzureAd()) {
+            authService.sjekkAtApplikasjonErIAllowList(allowlist);
         } else if (authService.erEksternBruker()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Eksternbruker ikke tillatt");
         }

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizationAnnotationHandler.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizationAnnotationHandler.java
@@ -1,0 +1,88 @@
+package no.nav.veilarboppfolging.utils.auth;
+
+import lombok.RequiredArgsConstructor;
+import no.nav.common.types.identer.AktorId;
+import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppfolging.service.AuthService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.servlet.http.HttpServletRequest;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class AuthorizationAnnotationHandler {
+
+    private final AuthService authService;
+
+    private static final List<Class<? extends Annotation>> SUPPORTED_ANNOTATIONS = List.of(
+            AuthorizeFnr.class,
+            AuthorizeAktorId.class
+    );
+
+    private void authorizeRequest(Annotation annotation, HttpServletRequest request) {
+        var idToken = authService.getInnloggetBrukerToken();
+        if (idToken == null || idToken.isEmpty()) {
+            throw new UnauthorizedException("Missing token");
+        }
+        if (annotation instanceof AuthorizeFnr) {
+            var fnr = Fnr.of(getFnr(request));
+            var allowlist = ((AuthorizeFnr) annotation).allowlist();
+            handleAuthorizeFnr(fnr, allowlist);
+        } else if (annotation instanceof AuthorizeAktorId) {
+            var allowlist = ((AuthorizeFnr) annotation).allowlist();
+            var aktorId = AktorId.of(getAktorId(request));
+            handleAuthorizeAktorId(aktorId, allowlist);
+        }
+    }
+
+    private void handleAuthorizeFnr(Fnr fnr, String[] allowlist) {
+        authService.sjekkAtApplikasjonErIAllowList(allowlist);
+        if (authService.erEksternBruker()) {
+            authService.harEksternBrukerTilgang(fnr);
+        } else if (authService.erInternBruker()) {
+            authService.sjekkLesetilgangMedFnr(fnr);
+        }
+    }
+
+    private void handleAuthorizeAktorId(AktorId aktorId, String[] allowlist) {
+        authService.sjekkAtApplikasjonErIAllowList(allowlist);
+        if (authService.erInternBruker()) {
+            authService.sjekkLesetilgangMedAktorId(aktorId);
+        } else if (authService.erEksternBruker()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Eksternbruker ikke tillatt");
+        }
+    }
+
+    public void doAuthorizationCheckIfTagged(Method handlerMethod, HttpServletRequest request) {
+        Optional.ofNullable(getAnnotation(handlerMethod, SUPPORTED_ANNOTATIONS))
+            // Skip if not tagged
+            .ifPresent((Annotation annotation) -> {
+                authorizeRequest(annotation, request);
+            });
+    }
+
+    protected Annotation getAnnotation(Method method, List<Class<? extends Annotation>> types) {
+        return Optional.ofNullable(findAnnotation(types, method.getAnnotations()))
+                .orElseGet(() -> findAnnotation(types, method.getDeclaringClass().getAnnotations()));
+    }
+
+    private static Annotation findAnnotation(List<Class<? extends Annotation>> types, Annotation... annotations) {
+        return Arrays.stream(annotations)
+                .filter(a -> types.contains(a.annotationType()))
+                .findFirst()
+                .orElse(null);
+    }
+    private String getFnr(HttpServletRequest request) {
+        /* Get fnr from headers instead of query when supported by clients */
+        return request.getParameter("fnr");
+    }
+    private String getAktorId(HttpServletRequest request) {
+        return request.getParameter("aktorId");
+    }
+
+}

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizationAnnotationHandler.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizationAnnotationHandler.java
@@ -32,31 +32,29 @@ public class AuthorizationAnnotationHandler {
         if (annotation instanceof AuthorizeFnr) {
             var fnr = Fnr.of(getFnr(request));
             var allowlist = ((AuthorizeFnr) annotation).allowlist();
-            handleAuthorizeFnr(fnr, allowlist);
+            authorizeFnr(fnr, allowlist);
         } else if (annotation instanceof AuthorizeAktorId) {
             var allowlist = ((AuthorizeAktorId) annotation).allowlist();
             var aktorId = AktorId.of(getAktorId(request));
-            handleAuthorizeAktorId(aktorId, allowlist);
+            authorizeAktorId(aktorId, allowlist);
         }
     }
 
-    private void handleAuthorizeFnr(Fnr fnr, String[] allowlist) {
-        if (authService.erEksternBruker()) {
-            authService.harEksternBrukerTilgang(fnr);
-        } else if (authService.erSystemBrukerFraAzureAd()) {
+    private void authorizeFnr(Fnr fnr, String[] allowlist) {
+        if (authService.erSystemBrukerFraAzureAd()) {
             authService.sjekkAtApplikasjonErIAllowList(allowlist);
-        } else if (authService.erInternBruker()) {
+        } else {
             authService.sjekkLesetilgangMedFnr(fnr);
         }
     }
 
-    private void handleAuthorizeAktorId(AktorId aktorId, String[] allowlist) {
+    private void authorizeAktorId(AktorId aktorId, String[] allowlist) {
         if (authService.erInternBruker()) {
             authService.sjekkLesetilgangMedAktorId(aktorId);
         } else if (authService.erSystemBrukerFraAzureAd()) {
             authService.sjekkAtApplikasjonErIAllowList(allowlist);
         } else if (authService.erEksternBruker()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Eksternbruker ikke tillatt");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Eksternbruker ikke tillatt");
         }
     }
 

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizationConfiguration.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizationConfiguration.java
@@ -1,0 +1,19 @@
+package no.nav.veilarboppfolging.utils.auth;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class AuthorizationConfiguration implements WebMvcConfigurer {
+
+    @Autowired
+    private AuthorizationInterceptor authorizationInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authorizationInterceptor);
+    }
+
+}

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizationInterceptor.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizationInterceptor.java
@@ -1,0 +1,36 @@
+package no.nav.veilarboppfolging.utils.auth;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.veilarboppfolging.service.AuthService;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Slf4j
+@Component
+public class AuthorizationInterceptor implements HandlerInterceptor {
+    private final AuthorizationAnnotationHandler annotationHandler;
+
+    public AuthorizationInterceptor(AuthService authService) {
+        this.annotationHandler = new AuthorizationAnnotationHandler(authService);
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (handler instanceof HandlerMethod) {
+            try {
+                annotationHandler.doAuthorizationCheckIfTagged(((HandlerMethod) handler).getMethod(), request);
+            } catch (Exception e) {
+                log.error("Failed to process annotation", e);
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizationInterceptor.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizationInterceptor.java
@@ -26,6 +26,10 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
             try {
                 annotationHandler.doAuthorizationCheckIfTagged(((HandlerMethod) handler).getMethod(), request);
             } catch (Exception e) {
+                // Catch all exception except status-exceptions
+                if (e instanceof ResponseStatusException) {
+                    return true;
+                }
                 log.error("Failed to process annotation", e);
                 throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
             }

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizeAktorId.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizeAktorId.java
@@ -1,0 +1,14 @@
+package no.nav.veilarboppfolging.utils.auth;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({ METHOD, TYPE })
+public @interface AuthorizeAktorId {
+    String[] allowlist() default {};
+}

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizeFnr.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/AuthorizeFnr.java
@@ -1,0 +1,14 @@
+package no.nav.veilarboppfolging.utils.auth;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({ METHOD, TYPE })
+public @interface AuthorizeFnr {
+    String[] allowlist() default {};
+}

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/UnauthorizedException.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package no.nav.veilarboppfolging.utils.auth;
+
+public class UnauthorizedException extends RuntimeException {
+    UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/no/nav/veilarboppfolging/config/ApplicationTestConfig.java
+++ b/src/test/java/no/nav/veilarboppfolging/config/ApplicationTestConfig.java
@@ -6,6 +6,8 @@ import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import no.finn.unleash.UnleashContext;
 import no.nav.common.abac.Pep;
+import no.nav.common.audit_log.cef.CefMessage;
+import no.nav.common.audit_log.log.AuditLogger;
 import no.nav.common.auth.context.AuthContextHolder;
 import no.nav.common.auth.context.AuthContextHolderThreadLocal;
 import no.nav.common.featuretoggle.UnleashClient;
@@ -112,6 +114,21 @@ public class ApplicationTestConfig {
     @Bean
     public LeaderElectionClient leaderElectionClient() {
         return () -> true;
+    }
+
+    @Bean
+    public AuditLogger auditLogger() {
+        return new AuditLogger() {
+            @Override
+            public void log(CefMessage message) {
+                return;
+            }
+
+            @Override
+            public void log(String message) {
+                return;
+            }
+        };
     }
 
 

--- a/src/test/java/no/nav/veilarboppfolging/controller/AdminControllerTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/AdminControllerTest.java
@@ -7,6 +7,7 @@ import no.nav.veilarboppfolging.repository.VeilederTilordningerRepository;
 import no.nav.veilarboppfolging.service.AuthService;
 import no.nav.veilarboppfolging.service.KafkaRepubliseringService;
 import no.nav.veilarboppfolging.service.ManuellStatusService;
+import no.nav.veilarboppfolging.utils.auth.AuthorizationInterceptor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;

--- a/src/test/java/no/nav/veilarboppfolging/controller/v2/OppfolgingV2ControllerTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/v2/OppfolgingV2ControllerTest.java
@@ -34,7 +34,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = OppfolgingV2Controller.class, includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION))
+@WebMvcTest(controllers = OppfolgingV2Controller.class)
 class OppfolgingV2ControllerTest {
 
     @Autowired

--- a/src/test/java/no/nav/veilarboppfolging/service/AuthServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/AuthServiceTest.java
@@ -2,6 +2,8 @@ package no.nav.veilarboppfolging.service;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import no.nav.common.abac.Pep;
+import no.nav.common.audit_log.log.AuditLogger;
+import no.nav.common.audit_log.log.AuditLoggerImpl;
 import no.nav.common.auth.context.AuthContextHolder;
 import no.nav.common.auth.context.UserRole;
 import no.nav.common.client.aktoroppslag.AktorOppslagClient;
@@ -33,13 +35,16 @@ public class AuthServiceTest {
 
     private final EnvironmentProperties environmentProperties = mock(EnvironmentProperties.class);
 
+    private final AuditLogger auditLogger = mock(AuditLoggerImpl.class);
+
     private AuthService authService = new AuthService(
             authContextHolder,
             veilarbPep,
             aktorOppslagClient,
             serviceUserCredentials,
             azureAdOnBehalfOfTokenClient,
-            environmentProperties
+            environmentProperties,
+            auditLogger
     );
 
     @Test

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
@@ -2,6 +2,7 @@ package no.nav.veilarboppfolging.service;
 
 import lombok.SneakyThrows;
 import lombok.val;
+import no.nav.common.client.aktorregister.IngenGjeldendeIdentException;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
 import no.nav.pto_schema.kafka.json.topic.SisteOppfolgingsperiodeV1;
@@ -181,10 +182,11 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
     }
 
     @Test
-    public void ukjentAktor() {
+    public void skal_krasje_nar_aktorId_er_ukjent() {
         doCallRealMethod().when(authService).sjekkLesetilgangMedFnr(any());
-        doThrow(new IllegalArgumentException()).when(authService).getAktorIdOrThrow(FNR);
-        assertThrows(IllegalArgumentException.class, this::hentOppfolgingStatus);
+        when(authService.erEksternBruker()).thenReturn(false);
+        doThrow(new IngenGjeldendeIdentException()).when(authService).getAktorIdOrThrow(FNR);
+        assertThrows(IngenGjeldendeIdentException.class, this::hentOppfolgingStatus);
     }
 
     @Test


### PR DESCRIPTION
- Opprydding i authorization i endepunkter i OppfolginfolgingV2Controller, ingen av dem støttet tokenX OBO token veilarbdialog (og veilarbaktivitet) kaller disse endepunktene på vegne av en bruker. De bør la bruker (sub) propagere så langt som mulig i kallene både for at auditloggingen skal bli "riktig" og pga sikkerthet, feks hvis vi i DAB glemmer å gjøre authorization sjekk så har man i verste fall full tilgang. 