### PR TITLE
Change filter order

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/config/FilterConfig.java
+++ b/src/main/java/no/nav/veilarboppfolging/config/FilterConfig.java
@@ -76,10 +76,10 @@ public class FilterConfig {
         FilterRegistrationBean<OidcAuthenticationFilter> registration = new FilterRegistrationBean<>();
         OidcAuthenticationFilter authenticationFilter = new OidcAuthenticationFilter(
                 fromConfigs(
-                        loginserviceIdportenConfig(properties),
-                        naisStsAuthConfig(properties),
                         naisAzureAdConfig(properties),
-                        tokenxAuthConfig(properties)
+                        tokenxAuthConfig(properties),
+                        naisStsAuthConfig(properties),
+                        loginserviceIdportenConfig(properties)
                 )
         );
 


### PR DESCRIPTION
Hvis man er logget inn på feks dev.nav.no så har man en id-porten cookie og veilarboppfolging kommer til å tro man er en ekstern-bruker, når rekkefølgen skiftes så får tokenet i Authorization-headeren prioritet over selvbetjening-cookien