### PR TITLE
Dont auditlog empty enhet

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/controller/response/VeilederTilgang.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/response/VeilederTilgang.java
@@ -1,10 +1,10 @@
 package no.nav.veilarboppfolging.controller.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.experimental.Accessors;
 
 @Data
-@Accessors(chain = true)
+@AllArgsConstructor
 public class VeilederTilgang {
 
     private boolean tilgangTilBrukersKontor;

--- a/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
@@ -187,10 +187,12 @@ public class OppfolgingService {
     @SneakyThrows
     public VeilederTilgang hentVeilederTilgang(Fnr fnr) {
         authService.sjekkLesetilgangMedFnr(fnr);
-        Optional<VeilarbArenaOppfolging> arenaBruker = arenaOppfolgingService.hentOppfolgingFraVeilarbarena(fnr);
-        return arenaBruker.map(VeilarbArenaOppfolging::getNav_kontor)
+        return arenaOppfolgingService
+                .hentOppfolgingFraVeilarbarena(fnr)
+                .map(VeilarbArenaOppfolging::getNav_kontor)
                 .map(authService::harTilgangTilEnhet)
-                .map(VeilederTilgang::new).orElse(new VeilederTilgang(false));
+                .map(VeilederTilgang::new)
+                .orElse(new VeilederTilgang(false));
     }
 
     public List<OppfolgingsperiodeEntity> hentOppfolgingsperioder(Fnr fnr) {

--- a/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
@@ -188,9 +188,9 @@ public class OppfolgingService {
     public VeilederTilgang hentVeilederTilgang(Fnr fnr) {
         authService.sjekkLesetilgangMedFnr(fnr);
         Optional<VeilarbArenaOppfolging> arenaBruker = arenaOppfolgingService.hentOppfolgingFraVeilarbarena(fnr);
-        String oppfolgingsenhet = arenaBruker.map(VeilarbArenaOppfolging::getNav_kontor).orElse(null);
-        boolean tilgangTilEnhet = authService.harTilgangTilEnhet(oppfolgingsenhet);
-        return new VeilederTilgang().setTilgangTilBrukersKontor(tilgangTilEnhet);
+        return arenaBruker.map(VeilarbArenaOppfolging::getNav_kontor)
+                .map(authService::harTilgangTilEnhet)
+                .map(VeilederTilgang::new).orElse(new VeilederTilgang(false));
     }
 
     public List<OppfolgingsperiodeEntity> hentOppfolgingsperioder(Fnr fnr) {

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
@@ -11,6 +11,7 @@ import no.nav.tjeneste.virksomhet.ytelseskontrakt.v3.meldinger.HentYtelseskontra
 import no.nav.tjeneste.virksomhet.ytelseskontrakt.v3.meldinger.HentYtelseskontraktListeResponse;
 import no.nav.veilarboppfolging.client.dkif.DkifKontaktinfo;
 import no.nav.veilarboppfolging.client.veilarbarena.ArenaOppfolgingTilstand;
+import no.nav.veilarboppfolging.client.veilarbarena.VeilarbArenaOppfolging;
 import no.nav.veilarboppfolging.client.ytelseskontrakt.YtelseskontraktClient;
 import no.nav.veilarboppfolging.client.ytelseskontrakt.YtelseskontraktMapper;
 import no.nav.veilarboppfolging.client.ytelseskontrakt.YtelseskontraktResponse;
@@ -162,23 +163,36 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
     }
 
     @Test
-    public void medEnhetTilgang() {
+    public void hentVeilederTilgang__medEnhetTilgang() {
         when(authService.harTilgangTilEnhet(any())).thenReturn(true);
+        when(arenaOppfolgingService.hentOppfolgingFraVeilarbarena(any()))
+                .thenReturn(Optional.of(new VeilarbArenaOppfolging().setNav_kontor(ENHET)));
 
         arenaOppfolgingTilstand.setOppfolgingsenhet(ENHET);
 
         VeilederTilgang veilederTilgang = oppfolgingService.hentVeilederTilgang(FNR);
-        assertTrue(veilederTilgang.isTilgangTilBrukersKontor());
     }
 
     @Test
-    public void utenEnhetTilgang() {
-        when(authService.harTilgangTilEnhet(any())).thenReturn(false);
+    public void hentVeilederTilgang__utenEnhetTilgang() {
+        when(arenaOppfolgingService.hentOppfolgingFraVeilarbarena(any()))
+                .thenReturn(Optional.of(new VeilarbArenaOppfolging().setNav_kontor(ENHET)));
 
         arenaOppfolgingTilstand.setOppfolgingsenhet(ENHET);
 
-        VeilederTilgang veilederTilgang = oppfolgingService.hentVeilederTilgang(FNR);
-        assertThat(veilederTilgang.isTilgangTilBrukersKontor(), equalTo(false));
+        VeilederTilgang veilederIkkeTilgang = oppfolgingService.hentVeilederTilgang(FNR);
+        assertFalse(veilederIkkeTilgang.isTilgangTilBrukersKontor());
+    }
+
+    @Test
+    public void hentVeilederTilgang__skal_ikke_ha_tilgang_nar_bruker_ikke_har_enhet() {
+        when(arenaOppfolgingService.hentOppfolgingFraVeilarbarena(any()))
+                .thenReturn(Optional.of(new VeilarbArenaOppfolging().setNav_kontor(null)));
+
+        arenaOppfolgingTilstand.setOppfolgingsenhet(ENHET);
+
+        VeilederTilgang veilederIkkeTilgang = oppfolgingService.hentVeilederTilgang(FNR);
+        assertFalse(veilederIkkeTilgang.isTilgangTilBrukersKontor());
     }
 
     @Test


### PR DESCRIPTION
Fikk en god del nullpointerExceptions i prod pga auditlog ikke klarte å håndtere at destinationUserId (enhetId i dette tilfellet) var null 