### PR TITLE
TC-165 Rydde i feature toggles

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/service/KafkaConsumerService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/KafkaConsumerService.java
@@ -81,9 +81,6 @@ public class KafkaConsumerService {
             log.info("Endring på oppfølgingsbruker fra Arena er eldre enn sist lagret endring. " +
                     "Dersom vi ikke utførte en rewind på topicen betyr dette at Arena har en uventet oppførsel. " +
                     "Denne loggmeldingen er kun til informasjon slik at vi eventuelt kan fange opp dette scenariet til ettertid.");
-            if (unleashService.skalIgnorereGamleEndringerFraVeilarbarena()) {
-                return;
-            }
         }
 
         var context = new AuthContext(

--- a/src/main/java/no/nav/veilarboppfolging/service/OppfolgingEndringService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/OppfolgingEndringService.java
@@ -64,12 +64,6 @@ public class OppfolgingEndringService {
 
         if (!erBrukerUnderOppfolging && erUnderOppfolgingIArena) {
             secureLog.info("Starter oppfølging på bruker som er under oppfølging i Arena, men ikke i veilarboppfolging. aktorId={}", aktorId);
-
-            if (!unleashService.skalOppdaterOppfolgingMedKafka()) {
-                secureLog.info("Oppdatering av oppfølging med kafka er ikke skrudd på. Stopper start av oppfølging for aktorId={}", aktorId);
-                return;
-            }
-
             oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(aktorId);
         } else if (erBrukerUnderOppfolging && !erUnderOppfolgingIArena && erInaktivIArena) {
             Optional<ArenaOppfolgingTilstand> maybeArenaTilstand = arenaOppfolgingService.hentOppfolgingTilstandDirekteFraArena(fnr);
@@ -87,12 +81,6 @@ public class OppfolgingEndringService {
 
                 if (skalAvsluttes) {
                     secureLog.info("Automatisk avslutting av oppfølging på bruker. aktorId={}", aktorId);
-
-                    if (!unleashService.skalOppdaterOppfolgingMedKafka()) {
-                        secureLog.info("Oppdatering av oppfølging med kafka er ikke skrudd på. Stopper avslutting av oppfølging for aktorId={}", aktorId);
-                        return;
-                    }
-
                     oppfolgingService.avsluttOppfolgingForBruker(aktorId, null, "Oppfølging avsluttet automatisk pga. inaktiv bruker som ikke kan reaktiveres");
                     metricsService.rapporterAutomatiskAvslutningAvOppfolging(true);
                 }

--- a/src/main/java/no/nav/veilarboppfolging/service/UnleashService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/UnleashService.java
@@ -8,17 +8,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UnleashService {
     private final static String IKKE_OPPDATER_OPPFOLGING_MED_SIDEEFFEKT = "veilarboppfolging.ikke_oppdater_oppfolging_med_sideeffekt";
-    private static final String SKAL_IGNORERE_GAMLE_ENDRINGER_FRA_VEILARBARENA = "veilarboppfolging.skal_ignorere_gamle_endringer_fra_veilarbarena";
 	private static final String POAO_TILGANG_ENABLED = "veilarboppfolging.poao-tilgang-enabled";
 
     private final UnleashClient unleashClient;
 
     public boolean skalIkkeOppdatereMedSideeffekt() {
         return unleashClient.isEnabled(IKKE_OPPDATER_OPPFOLGING_MED_SIDEEFFEKT);
-    }
-
-    public boolean skalIgnorereGamleEndringerFraVeilarbarena() {
-        return unleashClient.isEnabled(SKAL_IGNORERE_GAMLE_ENDRINGER_FRA_VEILARBARENA);
     }
 
 	public boolean skalBrukePoaoTilgang() {

--- a/src/main/java/no/nav/veilarboppfolging/service/UnleashService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/UnleashService.java
@@ -7,17 +7,11 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class UnleashService {
-    private final static String OPPDATER_OPPFOLGING_KAFKA = "veilarboppfolging.oppdater_oppfolging_kafka";
-
     private final static String IKKE_OPPDATER_OPPFOLGING_MED_SIDEEFFEKT = "veilarboppfolging.ikke_oppdater_oppfolging_med_sideeffekt";
     private static final String SKAL_IGNORERE_GAMLE_ENDRINGER_FRA_VEILARBARENA = "veilarboppfolging.skal_ignorere_gamle_endringer_fra_veilarbarena";
 	private static final String POAO_TILGANG_ENABLED = "veilarboppfolging.poao-tilgang-enabled";
 
     private final UnleashClient unleashClient;
-
-    public boolean skalOppdaterOppfolgingMedKafka() {
-        return unleashClient.isEnabled(OPPDATER_OPPFOLGING_KAFKA);
-    }
 
     public boolean skalIkkeOppdatereMedSideeffekt() {
         return unleashClient.isEnabled(IKKE_OPPDATER_OPPFOLGING_MED_SIDEEFFEKT);

--- a/src/main/java/no/nav/veilarboppfolging/service/UnleashService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/UnleashService.java
@@ -10,7 +10,6 @@ public class UnleashService {
     private final static String OPPDATER_OPPFOLGING_KAFKA = "veilarboppfolging.oppdater_oppfolging_kafka";
 
     private final static String IKKE_OPPDATER_OPPFOLGING_MED_SIDEEFFEKT = "veilarboppfolging.ikke_oppdater_oppfolging_med_sideeffekt";
-    private static final String LAGRE_VEILEDER_SOM_HAR_UTFORT_TILORDNING = "veilarboppfolging.lagre_veileder_som_har_utfort_tilordning";
     private static final String SKAL_IGNORERE_GAMLE_ENDRINGER_FRA_VEILARBARENA = "veilarboppfolging.skal_ignorere_gamle_endringer_fra_veilarbarena";
 	private static final String POAO_TILGANG_ENABLED = "veilarboppfolging.poao-tilgang-enabled";
 
@@ -22,10 +21,6 @@ public class UnleashService {
 
     public boolean skalIkkeOppdatereMedSideeffekt() {
         return unleashClient.isEnabled(IKKE_OPPDATER_OPPFOLGING_MED_SIDEEFFEKT);
-    }
-
-    public boolean skalLagreHvilkenVeilederSomHarUtfortTilordning() {
-        return unleashClient.isEnabled(LAGRE_VEILEDER_SOM_HAR_UTFORT_TILORDNING);
     }
 
     public boolean skalIgnorereGamleEndringerFraVeilarbarena() {

--- a/src/main/java/no/nav/veilarboppfolging/service/VeilederTilordningService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/VeilederTilordningService.java
@@ -33,7 +33,6 @@ public class VeilederTilordningService {
     private final VeilederHistorikkRepository veilederHistorikkRepository;
     private final TransactionTemplate transactor;
     private final KafkaProducerService kafkaProducerService;
-    private final UnleashService unleashService;
 
     @Autowired
     public VeilederTilordningService(
@@ -43,9 +42,8 @@ public class VeilederTilordningService {
             OppfolgingService oppfolgingService,
             VeilederHistorikkRepository veilederHistorikkRepository,
             TransactionTemplate transactor,
-            KafkaProducerService kafkaProducerService,
-            UnleashService unleashService) {
-
+            KafkaProducerService kafkaProducerService
+    ) {
         this.metricsService = metricsService;
         this.veilederTilordningerRepository = veilederTilordningerRepository;
         this.authService = authService;
@@ -53,7 +51,6 @@ public class VeilederTilordningService {
         this.veilederHistorikkRepository = veilederHistorikkRepository;
         this.transactor = transactor;
         this.kafkaProducerService = kafkaProducerService;
-        this.unleashService = unleashService;
     }
 
     public Optional<NavIdent> hentTilordnetVeilederIdent(Fnr fnr) {
@@ -120,13 +117,7 @@ public class VeilederTilordningService {
     private List<VeilederTilordning> tildelVeileder(List<VeilederTilordning> feilendeTilordninger, VeilederTilordning tilordning, AktorId aktorId, String eksisterendeVeileder, String innloggetVeilederId) {
         if (kanTilordneVeileder(eksisterendeVeileder, tilordning)) {
             if (nyVeilederHarTilgang(tilordning)) {
-                boolean skalLagreHvilkenVeilederSomHarUtfortTilordning = unleashService.skalLagreHvilkenVeilederSomHarUtfortTilordning();
-
-                if (skalLagreHvilkenVeilederSomHarUtfortTilordning) {
-                    lagreVeilederTilordning(aktorId, tilordning.getTilVeilederId(), innloggetVeilederId);
-                } else {
-                    lagreVeilederTilordning(aktorId, tilordning.getTilVeilederId(), null);
-                }
+                lagreVeilederTilordning(aktorId, tilordning.getTilVeilederId(), innloggetVeilederId);
             } else {
                 secureLog.info("Aktoerid {} kunne ikke tildeles. Ny veileder {} har ikke tilgang.", aktorId, tilordning.getTilVeilederId());
                 feilendeTilordninger.add(tilordning);

--- a/src/test/java/no/nav/veilarboppfolging/service/VeilederTilordningServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/VeilederTilordningServiceTest.java
@@ -60,9 +60,6 @@ public class VeilederTilordningServiceTest {
     @Mock
     private MetricsService metricsService;
 
-    @Mock
-    private UnleashService unleashService;
-    
     private VeilederTilordningService veilederTilordningService;
     
     @Before
@@ -78,8 +75,7 @@ public class VeilederTilordningServiceTest {
                     oppfolgingService,
                     veilederHistorikkRepository,
                     DbTestUtils.createTransactor(LocalH2Database.getDb()),
-                    mock(KafkaProducerService.class),
-                    unleashService
+                    mock(KafkaProducerService.class)
             );
         });
     }


### PR DESCRIPTION
Rydder opp i og fjerner funksjonsbrytere som ikke er relevante lengre:

* `veilarboppfolging.skal_ignorere_gamle_endringer_fra_veilarbarena`: Denne finnes ikke i Unleash, så den fjernes
* `veilarboppfolging.lagre_veileder_som_har_utfort_tilordning`: Denne er enabled for alle men har glemt å rydde den, så den fjernes
* `veilarboppfolging.oppdater_oppfolging_kafka`: Denne kjenner jeg ikke historikken på men den har vært enabled for alle de siste to årene, så den fjernes