### PR TITLE
Ta hensyn til både digital og manuell ved synk mot KRR

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/service/ManuellStatusService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/ManuellStatusService.java
@@ -91,6 +91,8 @@ public class ManuellStatusService {
 
         if (digdirKontaktinfo.isReservert()) {
             settBrukerTilManuellGrunnetReservasjonIKRR(aktorId);
+        } else {
+            settDigitalBruker(fnr);
         }
     }
 


### PR DESCRIPTION
Tidligere tok vi ikke høyde for om manuell status i KRR (Digdir) var satt til "ikke reservert", bare dersom den var satt til "reservert".

Tar nå høyde for begge deler.