### PR TITLE
Fikse feil der vi forsøkte å oppdatere manuell status som ekstern-bruker

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/service/ManuellStatusService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/ManuellStatusService.java
@@ -90,16 +90,16 @@ public class ManuellStatusService {
         DigdirKontaktinfo digdirKontaktinfo = hentDigdirKontaktinfo(fnr);
 
         if (digdirKontaktinfo.isReservert()) {
-            settBrukerTilManuellGrunnetReservasjonIKRR(aktorId);
+            settBrukerTilManuellGrunnetReservertIKRR(aktorId);
         } else {
-            settDigitalBruker(fnr);
+            settBrukerTilDigitalGrunnetIkkeReservertIKRR(aktorId);
         }
     }
 
-    public void settBrukerTilManuellGrunnetReservasjonIKRR(AktorId aktorId) {
+    public void settBrukerTilManuellGrunnetReservertIKRR(AktorId aktorId) {
         // Hvis bruker allerede er manuell så trenger vi ikke å sette status på nytt
         if (erManuell(aktorId)) {
-            log.info("Bruker er allerede manuell og trenger ikke å oppdateres med reservasjon fra KRR");
+            log.info("Bruker er allerede manuell og trenger ikke synkroniseres med KRR");
             return;
         }
 
@@ -111,6 +111,24 @@ public class ManuellStatusService {
                 .setOpprettetAv(SYSTEM);
 
         secureLog.info("Bruker er reservert i KRR, setter bruker aktorId={} til manuell", aktorId);
+        oppdaterManuellStatus(aktorId, manuellStatus);
+    }
+
+    public void settBrukerTilDigitalGrunnetIkkeReservertIKRR(AktorId aktorId) {
+        // Hvis bruker allerede er digital så trenger vi ikke å sette status på nytt
+        if (!erManuell(aktorId)) {
+            log.info("Bruker er allerede digital og trenger ikke synkroniseres med KRR");
+            return;
+        }
+
+        var manuellStatus = new ManuellStatusEntity()
+                .setAktorId(aktorId.get())
+                .setManuell(false)
+                .setDato(ZonedDateTime.now())
+                .setBegrunnelse("Brukeren er ikke lenger reservert i Kontakt- og reservasjonsregisteret")
+                .setOpprettetAv(SYSTEM);
+
+        secureLog.info("Bruker er ikke lenger reservert i KRR, setter bruker aktorId={} til digital", aktorId);
         oppdaterManuellStatus(aktorId, manuellStatus);
     }
 

--- a/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
@@ -325,7 +325,7 @@ public class OppfolgingService {
             kafkaProducerService.publiserOppfolgingsperiode(DtoMappers.tilSisteOppfolgingsperiodeV1(sistePeriode));
 
             if (kontaktinfo.isReservert()) {
-                manuellStatusService.settBrukerTilManuellGrunnetReservasjonIKRR(aktorId);
+                manuellStatusService.settBrukerTilManuellGrunnetReservertIKRR(aktorId);
             }
         });
     }

--- a/src/test/java/no/nav/veilarboppfolging/service/ManuellStatusServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/ManuellStatusServiceTest.java
@@ -203,13 +203,13 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
 
         assertFalse(manuellStatusService.erManuell(AKTOR_ID));
 
-        manuellStatusService.settBrukerTilManuellGrunnetReservasjonIKRR(AKTOR_ID);
+        manuellStatusService.settBrukerTilManuellGrunnetReservertIKRR(AKTOR_ID);
         assertTrue(manuellStatusService.erManuell(AKTOR_ID));
 
         manuellStatusService.settDigitalBruker(FNR);
         assertFalse(manuellStatusService.erManuell(AKTOR_ID));
 
-        manuellStatusService.settBrukerTilManuellGrunnetReservasjonIKRR(AKTOR_ID);
+        manuellStatusService.settBrukerTilManuellGrunnetReservertIKRR(AKTOR_ID);
         assertTrue(manuellStatusService.erManuell(AKTOR_ID));
 
 
@@ -221,7 +221,7 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
     public void settBrukerTilManuellGrunnetReservasjonIKRR__skal_lage_manuell_status() {
         gittAktivOppfolging();
 
-        manuellStatusService.settBrukerTilManuellGrunnetReservasjonIKRR(AKTOR_ID);
+        manuellStatusService.settBrukerTilManuellGrunnetReservertIKRR(AKTOR_ID);
 
         ManuellStatusEntity manuellStatus = manuellStatusService.hentManuellStatus(AKTOR_ID).orElseThrow();
 
@@ -244,7 +244,7 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
 
         manuellStatusRepository.create(manuellStatus);
 
-        manuellStatusService.settBrukerTilManuellGrunnetReservasjonIKRR(AKTOR_ID);
+        manuellStatusService.settBrukerTilManuellGrunnetReservertIKRR(AKTOR_ID);
 
         List<ManuellStatusEntity> history = manuellStatusRepository.history(AKTOR_ID);
 

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -389,7 +388,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
 
         oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(AKTOR_ID);
 
-        verify(manuellStatusService, never()).settBrukerTilManuellGrunnetReservasjonIKRR(any());
+        verify(manuellStatusService, never()).settBrukerTilManuellGrunnetReservertIKRR(any());
     }
 
     @Test
@@ -398,7 +397,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
 
         oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(AKTOR_ID);
 
-        verify(manuellStatusService, times(1)).settBrukerTilManuellGrunnetReservasjonIKRR(AKTOR_ID);
+        verify(manuellStatusService, times(1)).settBrukerTilManuellGrunnetReservertIKRR(AKTOR_ID);
     }
 
     private void assertUnderOppfolgingLagret(AktorId aktorId) {


### PR DESCRIPTION
Ved refresh i veilarbpersonflate synkroniserer vi med KRR for å sjekke om bruker er reservert (= manuell). I en tidligere endring så la vi til støtte for å også få med endringer fra KRR dersom bruker hadde opphevet reservasjon (= digital).

Pga. en feil i implementasjonen så ble det forsøkt å gjøre en verifikasjon på om brukeren var EKSTERN. Dette gir ikke mening, siden denne refresh-logikken (og påfølgende endring) skal registreres som utført av SYSTEM.