### PR TITLE
Update ManuellStatusV2Controller.java

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/controller/v2/ManuellStatusV2Controller.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/v2/ManuellStatusV2Controller.java
@@ -39,7 +39,7 @@ public class ManuellStatusV2Controller {
     public ManuellStatusV2Response hentManuellStatus(@RequestParam("fnr") Fnr fnr) {
         if (authService.erEksternBruker()) {
             authService.sjekkAtApplikasjonErIAllowList(ALLOWLIST);
-            authService.harEksternBrukerTilgang(fnr);
+            authService.sjekkLesetilgangMedFnr(fnr);
         } else if (authService.erSystemBrukerFraAzureAd()) {
             authService.sjekkAtApplikasjonErIAllowList(ALLOWLIST);
         } else  {


### PR DESCRIPTION
I forbindelse med at jeg ser på feilhåndtering rundt kode som gjør HTTP-kall `verilaboppfolging` så tok jeg en titt på HTTP-responsene som kan forventes fra `hentManuellStatus`.

Uten at jeg er kjent med prosjektet eller har åpnet det lokalt, så ser  det ut som at denne linjen (kallet til `harEksternBrukerTilgang`) ikke har noen åpenbar effekt (med mindre det er auditloggingen som er grunnen til at denne funksjonen blir kalt), men at kanskje det er `sjekkLesetilgangMedFnr` som er intensjonen i stedet?

Hvis dagens oppførsel stemmer så er det bare å se bort ifra denne PRen :smile: 