### PR TITLE
Fikse 500-feil fordi autoriseringslogikk ikke klarte å hente fødselsnummer

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/controller/v3/OppfolgingV3Controller.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/v3/OppfolgingV3Controller.java
@@ -35,9 +35,10 @@ public class OppfolgingV3Controller {
     private final static List<String> ALLOWLIST = List.of("veilarbregistrering");
     private final AktiverBrukerService aktiverBrukerService;
 
-    @AuthorizeFnr(allowlist = {"veilarbvedtaksstotte", "veilarbdialog", "veilarbaktivitet", "veilarbregistrering", "veilarbportefolje"})
     @PostMapping("/hent-oppfolging")
     public UnderOppfolgingV2Response underOppfolging(@RequestBody OppfolgingRequest oppfolgingRequest) {
+        String[] allowlist = {"veilarbvedtaksstotte", "veilarbdialog", "veilarbaktivitet", "veilarbregistrering", "veilarbportefolje"};
+        authService.authorizeRequest(oppfolgingRequest.fnr(), allowlist);
         return new UnderOppfolgingV2Response(oppfolgingService.erUnderOppfolging(oppfolgingRequest.fnr()));
     }
 
@@ -69,9 +70,10 @@ public class OppfolgingV3Controller {
         return tilDto(oppfolgingService.hentAvslutningStatus(oppfolgingRequest.fnr()));
     }
 
-    @AuthorizeFnr(allowlist = {"veilarbvedtaksstotte", "veilarbdialog", "veilarbaktivitet"})
     @PostMapping("/oppfolging/hent-gjeldende-periode")
     public ResponseEntity<OppfolgingPeriodeMinimalDTO> hentGjeldendePeriode(@RequestBody OppfolgingRequest oppfolgingRequest) {
+        String[] allowlist = {"veilarbvedtaksstotte", "veilarbdialog", "veilarbaktivitet"};
+        authService.authorizeRequest(oppfolgingRequest.fnr(), allowlist);
         return oppfolgingService.hentGjeldendeOppfolgingsperiode(oppfolgingRequest.fnr())
                 .map(DtoMappers::tilOppfolgingPeriodeMinimalDTO)
                 .map(op -> new ResponseEntity<>(op, HttpStatus.OK))

--- a/src/main/java/no/nav/veilarboppfolging/controller/v3/OppfolgingV3Controller.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/v3/OppfolgingV3Controller.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import static no.nav.veilarboppfolging.utils.DtoMappers.tilDto;
 import static no.nav.veilarboppfolging.utils.DtoMappers.tilOppfolgingPeriodeDTO;
+import static no.nav.veilarboppfolging.utils.auth.AllowListApplicationName.*;
 
 @RestController
 @RequestMapping("/api/v3")
@@ -32,12 +33,12 @@ public class OppfolgingV3Controller {
     private final AuthService authService;
     private final ManuellStatusService manuellStatusService;
     private final KvpService kvpService;
-    private final static List<String> ALLOWLIST = List.of("veilarbregistrering");
+    private final static List<String> ALLOWLIST = List.of(VEILARBREGISTRERING);
     private final AktiverBrukerService aktiverBrukerService;
 
     @PostMapping("/hent-oppfolging")
     public UnderOppfolgingV2Response underOppfolging(@RequestBody OppfolgingRequest oppfolgingRequest) {
-        String[] allowlist = {"veilarbvedtaksstotte", "veilarbdialog", "veilarbaktivitet", "veilarbregistrering", "veilarbportefolje"};
+        List<String> allowlist = List.of(VEILARBVEDTAKSSTOTTE, VEILARBDIALOG, VEILARBAKTIVITET, VEILARBREGISTRERING, VEILARBPORTEFOLJE);
         authService.authorizeRequest(oppfolgingRequest.fnr(), allowlist);
         return new UnderOppfolgingV2Response(oppfolgingService.erUnderOppfolging(oppfolgingRequest.fnr()));
     }
@@ -72,7 +73,7 @@ public class OppfolgingV3Controller {
 
     @PostMapping("/oppfolging/hent-gjeldende-periode")
     public ResponseEntity<OppfolgingPeriodeMinimalDTO> hentGjeldendePeriode(@RequestBody OppfolgingRequest oppfolgingRequest) {
-        String[] allowlist = {"veilarbvedtaksstotte", "veilarbdialog", "veilarbaktivitet"};
+        List<String> allowlist = List.of(VEILARBVEDTAKSSTOTTE, VEILARBDIALOG, VEILARBAKTIVITET);
         authService.authorizeRequest(oppfolgingRequest.fnr(), allowlist);
         return oppfolgingService.hentGjeldendeOppfolgingsperiode(oppfolgingRequest.fnr())
                 .map(DtoMappers::tilOppfolgingPeriodeMinimalDTO)

--- a/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
@@ -350,7 +350,7 @@ public class AuthService {
                 .orElse(null);
     }
 
-    public void authorizeRequest(EksternBrukerId ident, String[] allowList) {
+    public void authorizeRequest(EksternBrukerId ident, List<String> allowList) {
         var idToken = getInnloggetBrukerToken();
 
         if (idToken == null || idToken.isEmpty()) {
@@ -501,7 +501,7 @@ public class AuthService {
                 .build());
     }
 
-    private void authorizeFnr(Fnr fnr, String[] allowlist) {
+    private void authorizeFnr(Fnr fnr, List<String> allowlist) {
         if (erSystemBrukerFraAzureAd()) {
             sjekkAtApplikasjonErIAllowList(allowlist);
         } else {
@@ -509,7 +509,7 @@ public class AuthService {
         }
     }
 
-    private void authorizeAktorId(AktorId aktorId, String[] allowlist) {
+    private void authorizeAktorId(AktorId aktorId, List<String> allowlist) {
         if (erInternBruker()) {
             sjekkLesetilgangMedAktorId(aktorId);
         } else if (erSystemBrukerFraAzureAd()) {

--- a/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
@@ -141,19 +141,6 @@ public class AuthService {
         return erSystemBruker() && harAADRolleForSystemTilSystemTilgang();
     }
 
-    private boolean harAADRolleForSystemTilSystemTilgang() {
-        return authContextHolder.getIdTokenClaims()
-                .flatMap(claims -> {
-                    try {
-                        return Optional.ofNullable(claims.getStringListClaim("roles"));
-                    } catch (ParseException e) {
-                        return Optional.empty();
-                    }
-                })
-                .orElse(emptyList())
-                .contains("access_as_application");
-    }
-
     public boolean erEksternBruker() {
         return authContextHolder.erEksternBruker();
     }
@@ -225,46 +212,6 @@ public class AuthService {
     public void sjekkSkrivetilgangMedAktorId(AktorId aktorId) {
         sjekkTilgang(ActionId.WRITE, aktorId);
     }
-
-    private void sjekkTilgang(ActionId actionId, AktorId aktorId) {
-        Optional<String> sikkerhetsnivaa = hentSikkerhetsnivaa();
-        if (erInternBruker()) {
-            Decision decision = poaoTilgangClient.evaluatePolicy(new NavAnsattTilgangTilEksternBrukerPolicyInput(
-                    hentInnloggetVeilederUUID(), mapActionTypeToTilgangsType(actionId), getFnrOrThrow(aktorId).get()
-            )).getOrThrow();
-            auditLogWithMessageAndDestinationUserId(
-                    "Veileder har gjort oppslag på aktorid",
-                    aktorId.get(),
-                    authContextHolder.getNavIdent().orElse(NavIdent.of(UKJENT_NAV_IDENT)).get(),
-                    decision.isPermit() ? AuthorizationDecision.PERMIT : AuthorizationDecision.DENY
-            );
-            if (decision.isDeny()) {
-                throw new ResponseStatusException(HttpStatus.FORBIDDEN);
-            }
-        } else if (erEksternBruker() && sikkerhetsnivaa.isPresent() && sikkerhetsnivaa.get().equals("Level4")) {
-            Decision decision = poaoTilgangClient.evaluatePolicy(new EksternBrukerTilgangTilEksternBrukerPolicyInput(
-                    hentInnloggetPersonIdent(), getFnrOrThrow(aktorId).get()
-            )).getOrThrow();
-            auditLogWithMessageAndDestinationUserId(
-                    "Ekstern bruker har gjort oppslag på aktorid",
-                    aktorId.get(),
-                    hentInnloggetPersonIdent(),
-                    decision.isPermit() ? AuthorizationDecision.PERMIT : AuthorizationDecision.DENY
-            );
-            if (decision.isDeny()) {
-                throw new ResponseStatusException(HttpStatus.FORBIDDEN);
-            }
-
-        } else if (erSystemBruker()) {
-            if (!veilarbPep.harTilgangTilPerson(getInnloggetBrukerToken(), actionId, aktorId)) {
-                // TODO: skriv oss bort fra abac for systembruker
-                throw new ResponseStatusException(HttpStatus.FORBIDDEN);
-            }
-        } else {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
-        }
-    }
-
 
     public void sjekkTilgangTilEnhet(String enhetId) {
         if (!harTilgangTilEnhet(enhetId)) {
@@ -352,14 +299,6 @@ public class AuthService {
         return machineToMachineTokenClient.createMachineToMachineToken(scope);
     }
 
-    private boolean erAadOboToken() {
-        Optional<String> navIdentClaim = authContextHolder.getIdTokenClaims()
-                .flatMap((claims) -> authContextHolder.getStringClaim(claims, "NAVident"));
-        return authContextHolder.getIdTokenClaims().map(JWTClaimsSet::getIssuer).filter(environmentProperties.getNaisAadIssuer()::equals).isPresent()
-                && authContextHolder.getIdTokenClaims().map(x -> x.getClaim("oid")).isPresent()
-                && navIdentClaim.isPresent();
-    }
-
     // NAV ident, fnr eller annen ID
     public String getInnloggetBrukerIdent() {
         return authContextHolder.getUid()
@@ -372,17 +311,6 @@ public class AuthService {
         }
         return getInnloggetBrukerIdent();
     }
-
-    @SneakyThrows
-    private Optional<NavIdent> getNavIdentClaimHvisTilgjengelig() {
-        if (erInternBruker()) {
-            return Optional.ofNullable(authContextHolder.requireIdTokenClaims().getStringClaim(AAD_NAV_IDENT_CLAIM))
-                    .filter(IdentUtils::erGydligNavIdent)
-                    .map(NavIdent::of);
-        }
-        return empty();
-    }
-
 
     public void sjekkAtApplikasjonErIAllowList(String[] allowlist) {
         sjekkAtApplikasjonErIAllowList(List.of(allowlist));
@@ -406,6 +334,90 @@ public class AuthService {
         return maybeClaims.map(claims -> hasIssuer(claims, "tokenx")).orElse(false);
     }
 
+    public String hentApplikasjonFraContext() {
+        return getFullAppName()
+                .map(claim -> claim.split(":"))
+                .filter(claims -> claims.length == 3)
+                .map(claims -> claims[2])
+                .orElse("");
+    }
+
+    public String hentInnloggetPersonIdent() {
+        return authContextHolder.getIdTokenClaims()
+                .flatMap(claims -> getStringClaimOrEmpty(claims, "pid"))
+                .orElse(null);
+    }
+
+    private boolean harAADRolleForSystemTilSystemTilgang() {
+        return authContextHolder.getIdTokenClaims()
+                .flatMap(claims -> {
+                    try {
+                        return Optional.ofNullable(claims.getStringListClaim("roles"));
+                    } catch (ParseException e) {
+                        return Optional.empty();
+                    }
+                })
+                .orElse(emptyList())
+                .contains("access_as_application");
+    }
+
+    private void sjekkTilgang(ActionId actionId, AktorId aktorId) {
+        Optional<String> sikkerhetsnivaa = hentSikkerhetsnivaa();
+        if (erInternBruker()) {
+            Decision decision = poaoTilgangClient.evaluatePolicy(new NavAnsattTilgangTilEksternBrukerPolicyInput(
+                    hentInnloggetVeilederUUID(), mapActionTypeToTilgangsType(actionId), getFnrOrThrow(aktorId).get()
+            )).getOrThrow();
+            auditLogWithMessageAndDestinationUserId(
+                    "Veileder har gjort oppslag på aktorid",
+                    aktorId.get(),
+                    authContextHolder.getNavIdent().orElse(NavIdent.of(UKJENT_NAV_IDENT)).get(),
+                    decision.isPermit() ? AuthorizationDecision.PERMIT : AuthorizationDecision.DENY
+            );
+            if (decision.isDeny()) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+            }
+        } else if (erEksternBruker() && sikkerhetsnivaa.isPresent() && sikkerhetsnivaa.get().equals("Level4")) {
+            Decision decision = poaoTilgangClient.evaluatePolicy(new EksternBrukerTilgangTilEksternBrukerPolicyInput(
+                    hentInnloggetPersonIdent(), getFnrOrThrow(aktorId).get()
+            )).getOrThrow();
+            auditLogWithMessageAndDestinationUserId(
+                    "Ekstern bruker har gjort oppslag på aktorid",
+                    aktorId.get(),
+                    hentInnloggetPersonIdent(),
+                    decision.isPermit() ? AuthorizationDecision.PERMIT : AuthorizationDecision.DENY
+            );
+            if (decision.isDeny()) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+            }
+
+        } else if (erSystemBruker()) {
+            if (!veilarbPep.harTilgangTilPerson(getInnloggetBrukerToken(), actionId, aktorId)) {
+                // TODO: skriv oss bort fra abac for systembruker
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+            }
+        } else {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
+    }
+
+    private boolean erAadOboToken() {
+        Optional<String> navIdentClaim = authContextHolder.getIdTokenClaims()
+                .flatMap((claims) -> authContextHolder.getStringClaim(claims, "NAVident"));
+        return authContextHolder.getIdTokenClaims().map(JWTClaimsSet::getIssuer).filter(environmentProperties.getNaisAadIssuer()::equals).isPresent()
+                && authContextHolder.getIdTokenClaims().map(x -> x.getClaim("oid")).isPresent()
+                && navIdentClaim.isPresent();
+    }
+
+    @SneakyThrows
+    private Optional<NavIdent> getNavIdentClaimHvisTilgjengelig() {
+        if (erInternBruker()) {
+            return Optional.ofNullable(authContextHolder.requireIdTokenClaims().getStringClaim(AAD_NAV_IDENT_CLAIM))
+                    .filter(IdentUtils::erGydligNavIdent)
+                    .map(NavIdent::of);
+        }
+        return empty();
+    }
+
     private static boolean hasIssuer(JWTClaimsSet claims, String issuerSubString) {
         var fullIssuerString = claims.getIssuer();
         return fullIssuerString.contains(issuerSubString);
@@ -422,14 +434,6 @@ public class AuthService {
         }
     }
 
-    public String hentApplikasjonFraContext() {
-        return getFullAppName()
-                .map(claim -> claim.split(":"))
-                .filter(claims -> claims.length == 3)
-                .map(claims -> claims[2])
-                .orElse("");
-    }
-
     private static Optional<String> getStringClaimOrEmpty(JWTClaimsSet claims, String claimName) {
         try {
             return ofNullable(claims.getStringClaim(claimName));
@@ -443,12 +447,6 @@ public class AuthService {
                 .flatMap(claims -> getStringClaimOrEmpty(claims, "oid"))
                 .map(UUID::fromString)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "Fant ikke oid for innlogget veileder"));
-    }
-
-    public String hentInnloggetPersonIdent() {
-        return authContextHolder.getIdTokenClaims()
-                .flatMap(claims -> getStringClaimOrEmpty(claims, "pid"))
-                .orElse(null);
     }
 
     private Optional<String> hentSikkerhetsnivaa() {

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/AllowListApplicationName.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/AllowListApplicationName.java
@@ -1,6 +1,9 @@
 package no.nav.veilarboppfolging.utils.auth;
 
 public class AllowListApplicationName {
+
+    private AllowListApplicationName() {}
+
     public static String VEILARBVEDTAKSSTOTTE = "veilarbvedtaksstotte";
     public static String VEILARBDIALOG = "veilarbdialog";
     public static String VEILARBAKTIVITET = "veilarbaktivitet";

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/AllowListApplicationName.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/AllowListApplicationName.java
@@ -1,0 +1,9 @@
+package no.nav.veilarboppfolging.utils.auth;
+
+public class AllowListApplicationName {
+    public static String VEILARBVEDTAKSSTOTTE = "veilarbvedtaksstotte";
+    public static String VEILARBDIALOG = "veilarbdialog";
+    public static String VEILARBAKTIVITET = "veilarbaktivitet";
+    public static String VEILARBREGISTRERING = "veilarbregistrering";
+    public static String VEILARBPORTEFOLJE = "veilarbportefolje";
+}

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/AllowListApplicationName.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/AllowListApplicationName.java
@@ -4,9 +4,9 @@ public class AllowListApplicationName {
 
     private AllowListApplicationName() {}
 
-    public static String VEILARBVEDTAKSSTOTTE = "veilarbvedtaksstotte";
-    public static String VEILARBDIALOG = "veilarbdialog";
-    public static String VEILARBAKTIVITET = "veilarbaktivitet";
-    public static String VEILARBREGISTRERING = "veilarbregistrering";
-    public static String VEILARBPORTEFOLJE = "veilarbportefolje";
+    public static final String VEILARBVEDTAKSSTOTTE = "veilarbvedtaksstotte";
+    public static final String VEILARBDIALOG = "veilarbdialog";
+    public static final String VEILARBAKTIVITET = "veilarbaktivitet";
+    public static final String VEILARBREGISTRERING = "veilarbregistrering";
+    public static final String VEILARBPORTEFOLJE = "veilarbportefolje";
 }

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/UnauthorizedException.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/UnauthorizedException.java
@@ -1,7 +1,7 @@
 package no.nav.veilarboppfolging.utils.auth;
 
 public class UnauthorizedException extends RuntimeException {
-    UnauthorizedException(String message) {
+    public UnauthorizedException(String message) {
         super(message);
     }
 }

--- a/src/test/java/no/nav/veilarboppfolging/service/AuthServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/AuthServiceTest.java
@@ -39,8 +39,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 import static no.nav.common.auth.Constants.AAD_NAV_IDENT_CLAIM;
 import static no.nav.common.test.auth.AuthTestUtils.TEST_AUDIENCE;
+import static no.nav.veilarboppfolging.test.TestData.*;
 import static no.nav.veilarboppfolging.utils.auth.AllowListApplicationName.VEILARBAKTIVITET;
-import static no.nav.veilarboppfolging.utils.auth.AuthorizationAnnotationHandlerTest.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -344,7 +344,7 @@ public class AuthServiceTest {
         setupAuthService();
 
         List<String> allowList = List.of(VEILARBAKTIVITET);
-        assertDoesNotThrow(() -> authService.authorizeRequest(FNR, allowList));
+        assertDoesNotThrow(() -> authService.authorizeRequest(TEST_FNR_2, allowList));
     }
 
     @SneakyThrows
@@ -354,7 +354,7 @@ public class AuthServiceTest {
         setupAuthService();
 
         List<String> allowList = List.of(VEILARBAKTIVITET);
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> authService.authorizeRequest(FNR, allowList));
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> authService.authorizeRequest(TEST_FNR_2, allowList));
         Assertions.assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
@@ -364,7 +364,7 @@ public class AuthServiceTest {
         setUpExternalUserAuthOk();
         setupAuthService();
 
-        assertDoesNotThrow(() -> authService.authorizeRequest(FNR, emptyList()));
+        assertDoesNotThrow(() -> authService.authorizeRequest(TEST_FNR_2, emptyList()));
     }
 
     @SneakyThrows
@@ -383,8 +383,8 @@ public class AuthServiceTest {
         setupInternalUserAuthOk();
         setupAuthService();
 
-        when(aktorOppslagClient.hentAktorId(FNR)).thenReturn(AKTOR_ID);
-        assertDoesNotThrow(() -> authService.authorizeRequest(FNR, emptyList()));
+        when(aktorOppslagClient.hentAktorId(TEST_FNR_2)).thenReturn(TEST_AKTOR_ID_3);
+        assertDoesNotThrow(() -> authService.authorizeRequest(TEST_FNR_2, emptyList()));
     }
 
     @SneakyThrows
@@ -393,7 +393,7 @@ public class AuthServiceTest {
         setUpExternalUserAuthOk();
         setupAuthService();
 
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> authService.authorizeRequest(AKTOR_ID, emptyList()));
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> authService.authorizeRequest(TEST_AKTOR_ID_3, emptyList()));
         Assertions.assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
@@ -403,7 +403,7 @@ public class AuthServiceTest {
         setupInternalUserAuthOk();
         setupAuthService();
 
-        assertDoesNotThrow(() -> authService.authorizeRequest(AKTOR_ID, emptyList()));
+        assertDoesNotThrow(() -> authService.authorizeRequest(TEST_AKTOR_ID_3, emptyList()));
     }
 
     private void setupAuthService() {
@@ -421,7 +421,7 @@ public class AuthServiceTest {
 
     private void setupSystemUserAuthOk() {
         JWTClaimsSet claims = new JWTClaimsSet.Builder()
-                .issuer(AZURE_ISSUER)
+                .issuer(TEST_AZURE_ISSUER)
                 .claim("azp_name", "cluster:team:veilarbaktivitet")
                 .claim("roles", Collections.singletonList("access_as_application"))
                 .build();
@@ -437,7 +437,7 @@ public class AuthServiceTest {
 
     private void setupSystemUserNotInAllowList() {
         JWTClaimsSet claims = new JWTClaimsSet.Builder()
-                .issuer(AZURE_ISSUER)
+                .issuer(TEST_AZURE_ISSUER)
                 .claim("azp_name", "cluster:team:veilarbhacker")
                 .claim("roles", Collections.singletonList("access_as_application"))
                 .build();
@@ -453,12 +453,12 @@ public class AuthServiceTest {
 
     private void setUpExternalUserAuthOk() {
         JWTClaimsSet claims = new JWTClaimsSet.Builder()
-                .subject(FNR.get())
-                .claim("pid", FNR.get())
+                .subject(TEST_FNR_2.get())
+                .claim("pid", TEST_FNR_2.get())
                 .claim("acr", "Level4")
                 .claim("client_id", "test_client_id")
                 .audience(TEST_AUDIENCE)
-                .issuer(TOKENDINGS_ISSUER)
+                .issuer(TEST_TOKENDINGS_ISSUER)
                 .build();
 
         AuthContext authContext = new AuthContext(
@@ -474,11 +474,11 @@ public class AuthServiceTest {
         UUID uuid = UUID.randomUUID();
 
         JWTClaimsSet claims = new JWTClaimsSet.Builder()
-                .subject(VEILEDER.get())
-                .issuer(AZURE_ISSUER)
+                .subject(TEST_NAV_IDENT_2.get())
+                .issuer(TEST_AZURE_ISSUER)
                 .audience(TEST_AUDIENCE)
                 .claim("oid", uuid.toString())
-                .claim(AAD_NAV_IDENT_CLAIM, VEILEDER.get())
+                .claim(AAD_NAV_IDENT_CLAIM, TEST_NAV_IDENT_2.get())
                 .claim("azp_name", "test_client_id")
                 .build();
 
@@ -490,9 +490,9 @@ public class AuthServiceTest {
         this.authContextHolder = AuthContextHolderThreadLocal.instance();
         this.authContextHolder.setContext(authContext);
 
-        when(aktorOppslagClient.hentFnr(AKTOR_ID)).thenReturn(FNR);
+        when(aktorOppslagClient.hentFnr(TEST_AKTOR_ID_3)).thenReturn(TEST_FNR_2);
 
         Decision decision = mock(Decision.class);
-        doReturn(new ApiResult<>(null, decision)).when(poaoTilgangClient).evaluatePolicy(argThat(new PolicyInputMatcher(uuid, FNR.get())));
+        doReturn(new ApiResult<>(null, decision)).when(poaoTilgangClient).evaluatePolicy(argThat(new PolicyInputMatcher(uuid, TEST_FNR_2.get())));
     }
 }

--- a/src/test/java/no/nav/veilarboppfolging/test/TestData.java
+++ b/src/test/java/no/nav/veilarboppfolging/test/TestData.java
@@ -8,12 +8,13 @@ import no.nav.common.types.identer.NavIdent;
 public class TestData {
 
     public final static Fnr TEST_FNR = Fnr.of("12345678900");
-
+    public final static Fnr TEST_FNR_2 = Fnr.of("12345678901");
     public final static AktorId TEST_AKTOR_ID = AktorId.of("11122233334445");
-
     public final static AktorId TEST_AKTOR_ID_2 = AktorId.of("5556667778889");
-
+    public final static AktorId TEST_AKTOR_ID_3 = AktorId.of("3409823");
     public final static NavIdent TEST_NAV_IDENT = NavIdent.of("Z112233");
-
     public final static EnhetId TEST_ENHET_ID = EnhetId.of("0123");
+    public final static NavIdent TEST_NAV_IDENT_2 = NavIdent.of("Z123456");
+    public final static String TEST_TOKENDINGS_ISSUER = "https://tokendings";
+    public final static String TEST_AZURE_ISSUER = "microsoftonline.com";
 }

--- a/src/test/java/no/nav/veilarboppfolging/utils/auth/AuthorizationAnnotationHandlerTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/utils/auth/AuthorizationAnnotationHandlerTest.java
@@ -43,15 +43,13 @@ import static org.mockito.Mockito.*;
 import static org.springframework.beans.factory.support.ManagedList.of;
 
 @ExtendWith(MockitoExtension.class)
-class AuthorizationAnnotationHandlerTest {
+public class AuthorizationAnnotationHandlerTest {
 
-    private final static Fnr FNR = Fnr.of("12345678901");
-    private final static NavIdent VEILEDER = NavIdent.of("Z123456");
-
-    private final static AktorId AKTOR_ID = AktorId.of("3409823");
-
-    private final static String TOKENDINGS_ISSUER = "https://tokendings";
-    private final static String AZURE_ISSUER = "microsoftonline.com";
+    public final static Fnr FNR = Fnr.of("12345678901");
+    public final static NavIdent VEILEDER = NavIdent.of("Z123456");
+    public final static AktorId AKTOR_ID = AktorId.of("3409823");
+    public final static String TOKENDINGS_ISSUER = "https://tokendings";
+    public final static String AZURE_ISSUER = "microsoftonline.com";
 
     @Mock
     private Pep veilarbPep;
@@ -81,29 +79,12 @@ class AuthorizationAnnotationHandlerTest {
 
     @SneakyThrows
     @Test
-    void should_allow_system_user_if_in_allowlist_auth_service() {
-        setupSystemUserAuthOk();
-        List<String> allowList = List.of(VEILARBAKTIVITET);
-        assertDoesNotThrow(() -> authService.authorizeRequest(FNR, allowList));
-    }
-
-    @SneakyThrows
-    @Test
     void should_not_allow_system_user_if_not_in_allowlist() {
         setupSystemUserNotInAllowList();
         Method method = OppfolgingV2Controller.class.getMethod("hentGjeldendePeriode", Fnr.class);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setParameter("fnr", FNR.get());
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> annotationHandler.doAuthorizationCheckIfTagged(method, request));
-        Assertions.assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-    }
-
-    @SneakyThrows
-    @Test
-    void should_not_allow_system_user_if_not_in_allowlist_auth_service() {
-        setupSystemUserNotInAllowList();
-        List<String> allowList = List.of(VEILARBAKTIVITET);
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> authService.authorizeRequest(FNR, allowList));
         Assertions.assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
@@ -119,13 +100,6 @@ class AuthorizationAnnotationHandlerTest {
 
     @SneakyThrows
     @Test
-    void should_allow_external_user_if_access_self_auth_service() {
-        setUpExternalUserAuthOk();
-        assertDoesNotThrow(() -> authService.authorizeRequest(FNR, emptyList()));
-    }
-
-    @SneakyThrows
-    @Test
     void should_not_allow_external_user_if_access_other() {
         setUpExternalUserAuthOk();
         Method method = OppfolgingV2Controller.class.getMethod("hentGjeldendePeriode", Fnr.class);
@@ -133,14 +107,6 @@ class AuthorizationAnnotationHandlerTest {
         String otherFnr = "11120231920";
         request.setParameter("fnr", otherFnr);
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> annotationHandler.doAuthorizationCheckIfTagged(method, request));
-        Assertions.assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-    }
-
-    @SneakyThrows
-    @Test
-    void should_not_allow_external_user_if_access_other_auth_service() {
-        setUpExternalUserAuthOk();
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> authService.authorizeRequest(Fnr.of("11120231920"), emptyList()));
         Assertions.assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
@@ -158,28 +124,12 @@ class AuthorizationAnnotationHandlerTest {
 
     @SneakyThrows
     @Test
-    void should_allow_internal_user_if_access_ok_auth_service() {
-        setupInternalUserAuthOk();
-        when(aktorOppslagClient.hentAktorId(FNR)).thenReturn(AKTOR_ID);
-        assertDoesNotThrow(() -> authService.authorizeRequest(FNR, emptyList()));
-    }
-
-    @SneakyThrows
-    @Test
     void external_user_can_not_query_using_aktorid() {
         setUpExternalUserAuthOk();
         Method method = OppfolgingV2Controller.class.getMethod("hentOppfolgingsperioder", AktorId.class);
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setParameter("aktorId", AKTOR_ID.get());
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> annotationHandler.doAuthorizationCheckIfTagged(method, request));
-        Assertions.assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-    }
-
-    @SneakyThrows
-    @Test
-    void external_user_can_not_query_using_aktorid_auth_service() {
-        setUpExternalUserAuthOk();
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> authService.authorizeRequest(AKTOR_ID, emptyList()));
         Assertions.assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
@@ -192,13 +142,6 @@ class AuthorizationAnnotationHandlerTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setParameter("aktorId", AKTOR_ID.get());
         assertDoesNotThrow(() -> annotationHandler.doAuthorizationCheckIfTagged(method, request));
-    }
-
-    @SneakyThrows
-    @Test
-    void internal_user_can_query_using_aktorid_auth_service() {
-        setupInternalUserAuthOk();
-        assertDoesNotThrow(() -> authService.authorizeRequest(AKTOR_ID, emptyList()));
     }
 
     private void setupServices() {


### PR DESCRIPTION
Når man bruker `@AuthorizeFnr`-annotasjonen skjer følgende:

1. Request kommer inn til appen
2. Request går gjennom `AuthorizationAnnotationHandler`
3. `AuthorizationAnnotationHandler` gjør autoriseringssjekk på om autentisert bruker har lov å gjøre operasjoner på person spesifisert med fødselsnummer i request
4. Dersom sjekken passerer sendes request videre til den aktuelle controller-metoden

I sjekken som gjøres i punkt 3 så forsøker man å hente fødselsnummer fra request parameter (aka. query-string). Dette vil ikke fungere for de nye endepunktene (`OppfolgingV3Controller.java`) siden fødselsnummer nå ligger i request body-en. Dette resulterer i en exception fordi fødselsnummer er `null` når det egentlig skulle hatt en verdi.

Dette kan nok løses på flere måter, men jeg kom frem til at den enkleste måten var å gå bort fra å bruke annotasjoner og heller flytte relevant autoriseringslogikk inn i `AuthService.java` og bruke dette rett fra controll-er metodene. 