### PR TITLE
Bytt til "nais/docker-build-push"-action

### DIFF
--- a/.github/workflows/deploy-feature.yml
+++ b/.github/workflows/deploy-feature.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_TAG: ${{ github.sha }}
-  IMAGE: ghcr.io/${{ github.repository }}/veilarboppfolging
   PRINT_PAYLOAD: true
 
 permissions:
@@ -19,27 +17,31 @@ jobs:
   test-build-and-push:
     name: Test, build and push
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
+
       - name: Build (skipping tests)
         run: mvn -B package -DskipTests
-      - uses: docker/login-action@v2
+
+      - name: Build and push Docker image
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          tags: ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+          team: pto
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
 
   deploy-dev:
     name: Deploy application to dev
@@ -48,10 +50,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Deploy application
         uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-fss
           RESOURCE: nais-dev.yaml
-          VAR: version=${{ env.IMAGE_TAG }},namespace=q1
+          VAR: image=${{ needs.test-build-and-push.outputs.image }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,6 @@ on:
       - main
 
 env:
-  IMAGE_TAG: ${{ github.sha }}
-  IMAGE: ghcr.io/${{ github.repository }}/veilarboppfolging
   PRINT_PAYLOAD: true
 
 permissions:
@@ -20,27 +18,31 @@ jobs:
   test-build-and-push:
     name: Test, build and push
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'temurin'
           cache: 'maven'
+
       - name: Build and test
         run: mvn -B package
-      - uses: docker/login-action@v2
+
+      - name: Build and push Docker image
+        uses: nais/docker-build-push@v0
+        id: docker-build-push
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          tags: ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+          team: pto
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
 
   deploy-dev:
     name: Deploy application to dev
@@ -49,13 +51,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Deploy application
         uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-fss
           RESOURCE: nais-dev.yaml
-          VAR: version=${{ env.IMAGE_TAG }},namespace=q1
+          VAR: image=${{ needs.test-build-and-push.outputs.image }}
 
   deploy-prod:
     name: Deploy application to prod
@@ -64,10 +67,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Deploy application
         uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-fss
           RESOURCE: nais-prod.yaml
-          VAR: version=${{ env.IMAGE_TAG }}
+          VAR: image=${{ needs.test-build-and-push.outputs.image }}

--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: pto
 spec:
-  image: ghcr.io/navikt/veilarboppfolging/veilarboppfolging:{{version}}
+  image: {{image}}
   ingresses:
     - https://veilarboppfolging.dev-fss-pub.nais.io
     - https://veilarboppfolging.dev.intern.nav.no

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: pto
 spec:
-  image: ghcr.io/navikt/veilarboppfolging/veilarboppfolging:{{version}}
+  image: {{image}}
   ingresses:
     - https://veilarboppfolging.prod-fss-pub.nais.io
     - https://veilarboppfolging.nais.adeo.no


### PR DESCRIPTION
Bytter fra `docker/build-push-action` GitHub action til å bruke NAIS sin `nais/docker-build-push` GitHub action. Dette gir oss en del fordeler blant annet mtp. stabilitet ved image-pulls da `nais/docker-build-push` går mot Google Artifact Registry (GAR) i stedet for GitHub Container Registry (GHCR), samt automatisk signering/scanning av Docker images via SALSA.

Det står en god del om dette i NAIS-docen, bla.a. [Salsa - NAIS](https://doc.nais.io/security/salsa/salsa) og [OCI registry migration - NAIS](https://doc.nais.io/guides/oci-migration/). Noen relevante utdrag:

> [SLSA](https://slsa.dev/) is short for Supply chain Levels for Software Artifacts pronounced salsa.
>
> It is a security framework, essentially a checklist comprising standards and controls aimed at preventing tampering, enhancing integrity, and securing both packages and infrastructure within our projects.

> If you utilize the [nais/docker-build-push](https://github.com/nais/docker-build-push) action for building and pushing your container image, you will automatically receive a signed attestation/SBOM (Software Bill of Materials) for your container image and its dependencies. 
>
> This SBOM will be uploaded to your container registry along with your image. The attestation is generated by the [Trivy](https://github.com/aquasecurity/trivy-action) GitHub action and signed using [cosign](https://github.com/sigstore/cosign).

> Upon deploying your image to NAIS, the attestation will undergo verification by the NAIS platform ([picante](https://github.com/nais/picante)) and will be uploaded to an SBOM analysis platform known as [Dependency-Track](https://dependencytrack.org/). In Dependency-Track, you can examine the attestation as well as the vulnerabilities present in your image and its dependencies.

> GHCR serves as a OCI registry hosted by GitHub, but it has certain limitations, such as imposing strict rate limits on the number of requests. We've encountered challenges with these rate limits, particularly when upgrading a cluster or restoring from a backup. In such instances, we've had to patiently wait for the rate limits to reset before deploying / restoring our applications.
>
> On the other hand, GAR is a OCI registry hosted by Google, and we find it to be a more favorable solution for our needs. Additionally, as we transition to the cloud, the seamless integration with the Google Cloud Platform further enhances its appeal as a beneficial option for our operations.

## Trello ticket number and link

- [TC-380](https://trello.com/c/9wLGC3Tp/380-bytte-fra-snyk-til-github-advanced-security)
