### PR TITLE
Bruker v2 på hent person fra KRR

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/client/digdir_krr/DigdirClient.java
+++ b/src/main/java/no/nav/veilarboppfolging/client/digdir_krr/DigdirClient.java
@@ -7,5 +7,10 @@ import java.util.Optional;
 
 public interface DigdirClient extends HealthCheck {
 
-    Optional<DigdirKontaktinfo> hentKontaktInfo(Fnr fnr);
+    /**
+     * Bruk hentKontaktInfoV2 istdet, den bruker v2 fra KRR
+     * **/
+    @Deprecated
+    Optional<KRRData> hentKontaktInfo(Fnr fnr);
+    Optional<KRRData> hentKontaktInfoV2(Fnr fnr);
 }

--- a/src/main/java/no/nav/veilarboppfolging/client/digdir_krr/DigdirClientImpl.java
+++ b/src/main/java/no/nav/veilarboppfolging/client/digdir_krr/DigdirClientImpl.java
@@ -47,7 +47,7 @@ public class DigdirClientImpl implements DigdirClient {
 	@Cacheable(CacheConfig.DIGDIR_KONTAKTINFO_CACHE_NAME)
 	@SneakyThrows
 	@Override
-	public Optional<DigdirKontaktinfo> hentKontaktInfo(Fnr fnr) {
+	public Optional<KRRData> hentKontaktInfo(Fnr fnr) {
 		Request request = new Request.Builder()
 				.url(joinPaths(digdirUrl, "/rest/v1/person?inkluderSikkerDigitalPost=false"))
 				.header(ACCEPT, APPLICATION_JSON_VALUE)
@@ -57,7 +57,29 @@ public class DigdirClientImpl implements DigdirClient {
 
 		try (Response response = client.newCall(request).execute()) {
 			RestUtils.throwIfNotSuccessful(response);
-			return RestUtils.parseJsonResponse(response, DigdirKontaktinfo.class);
+			return RestUtils.parseJsonResponse(response, DigdirKontaktinfo.class)
+					.map(DigdirKontaktinfo::toKrrData);
+		} catch (Exception e) {
+			log.error("Feil under henting av data fra Digdir_KRR", e);
+			return empty();
+		}
+	}
+
+	@Cacheable(CacheConfig.DIGDIR_KONTAKTINFO_CACHE_NAME)
+	@SneakyThrows
+	@Override
+	public Optional<KRRData> hentKontaktInfoV2(Fnr fnr) {
+		Request request = new Request.Builder()
+				.url(joinPaths(digdirUrl, "/rest/v2/person?inkluderSikkerDigitalPost=false"))
+				.header(ACCEPT, APPLICATION_JSON_VALUE)
+				.header(AUTHORIZATION, "Bearer " + getToken())
+				.header("Nav-Personident", fnr.get())
+				.build();
+
+		try (Response response = client.newCall(request).execute()) {
+			RestUtils.throwIfNotSuccessful(response);
+			return RestUtils.parseJsonResponse(response, KRRKontaktInfoV3.class)
+					.map(KRRKontaktInfoV3::toKrrData);
 		} catch (Exception e) {
 			log.error("Feil under henting av data fra Digdir_KRR", e);
 			return empty();

--- a/src/main/java/no/nav/veilarboppfolging/client/digdir_krr/DigdirKontaktinfo.java
+++ b/src/main/java/no/nav/veilarboppfolging/client/digdir_krr/DigdirKontaktinfo.java
@@ -2,10 +2,12 @@ package no.nav.veilarboppfolging.client.digdir_krr;
 
 import lombok.Data;
 import lombok.experimental.Accessors;
+import org.checkerframework.checker.units.qual.K;
 
 @Data
 @Accessors(chain = true)
 public class DigdirKontaktinfo {
+
    String personident;
    boolean aktiv;
    boolean kanVarsles;
@@ -18,4 +20,14 @@ public class DigdirKontaktinfo {
    String mobiltelefonnummer;
    String mobiltelefonnummerOppdatert;
    String mobiltelefonnummerVerifisert;
+
+   public KRRData toKrrData() {
+      return new KRRData(
+           personident,
+           kanVarsles,
+           reservert,
+           epostadresse,
+           mobiltelefonnummer
+      );
+   }
 }

--- a/src/main/java/no/nav/veilarboppfolging/client/digdir_krr/KRRData.java
+++ b/src/main/java/no/nav/veilarboppfolging/client/digdir_krr/KRRData.java
@@ -1,0 +1,16 @@
+package no.nav.veilarboppfolging.client.digdir_krr;
+
+import lombok.*;
+
+@AllArgsConstructor
+@With
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class KRRData {
+    String personident;
+    boolean kanVarsles;
+    boolean reservert;
+    String epostadresse;
+    String mobiltelefonnummer;
+}

--- a/src/main/java/no/nav/veilarboppfolging/client/digdir_krr/KRRKontaktInfoV3.java
+++ b/src/main/java/no/nav/veilarboppfolging/client/digdir_krr/KRRKontaktInfoV3.java
@@ -1,0 +1,58 @@
+package no.nav.veilarboppfolging.client.digdir_krr;
+
+public class KRRKontaktInfoV3 {
+    String personidentifikator;
+    JaEllerNei reservasjon;
+    String reservasjonstidspunkt;
+    String reservasjon_oppdatert;
+    KRRStatus status;
+    VarslingsStatus varslingsstatus;
+    KontaktInformasjon kontaktinformasjon;
+    DigitalPost digital_post;
+    String sertifikat;
+    String spraak;
+    String spraak_oppdatert;
+
+    public KRRData toKrrData() {
+        return new KRRData(
+            personidentifikator,
+            varslingsstatus == VarslingsStatus.KAN_VARSLES,
+            reservasjon == JaEllerNei.JA,
+            kontaktinformasjon.epostadresse,
+            kontaktinformasjon.mobiltelefonnummer
+        );
+    }
+}
+
+class DigitalPost {
+    String postkasseadresse;
+    String postkasseleverandoeradresse;
+}
+
+class KontaktInformasjon {
+    String epostadresse;
+    String epostadresse_oppdatert;
+    String epostadresse_sist_verifisert;
+    String epostadresse_sist_validert;
+    String mobiltelefonnummer;
+    String mobiltelefonnummer_oppdatert;
+    String mobiltelefonnummer_sist_verifisert;
+    String mobiltelefonnummer_sist_validert;
+    String mobiltelefonnummer_valideringstoken;
+}
+
+enum VarslingsStatus {
+    KAN_IKKE_VARSLES, // Person har ikke utgått kontaktinformasjon
+    KAN_VARSLES // Person har utgått kontaktinformasjon, er reservert, er slettet eller finnes ikke i registeret
+}
+
+enum KRRStatus {
+    AKTIV,
+    SLETTET,
+    IKKE_REGISTRERT
+}
+
+enum JaEllerNei {
+    JA,
+    NEI
+}

--- a/src/main/java/no/nav/veilarboppfolging/controller/v2/ManuellStatusV2Controller.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/v2/ManuellStatusV2Controller.java
@@ -2,6 +2,7 @@ package no.nav.veilarboppfolging.controller.v2;
 
 import lombok.RequiredArgsConstructor;
 import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppfolging.client.digdir_krr.KRRData;
 import no.nav.veilarboppfolging.controller.request.VeilederBegrunnelseDTO;
 import no.nav.veilarboppfolging.controller.v2.response.ManuellStatusV2Response;
 import no.nav.veilarboppfolging.controller.v2.response.ManuellV2Response;
@@ -48,7 +49,7 @@ public class ManuellStatusV2Controller {
             authService.sjekkLesetilgangMedFnr(fnr);
         }
 
-        DigdirKontaktinfo kontaktinfo = manuellStatusService.hentDigdirKontaktinfo(fnr);
+        KRRData kontaktinfo = manuellStatusService.hentDigdirKontaktinfo(fnr);
         boolean erManuell = manuellStatusService.erManuell(fnr);
 
         return new ManuellStatusV2Response(

--- a/src/main/java/no/nav/veilarboppfolging/controller/v3/ManuellStatusV3Controller.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/v3/ManuellStatusV3Controller.java
@@ -2,6 +2,7 @@ package no.nav.veilarboppfolging.controller.v3;
 
 import lombok.RequiredArgsConstructor;
 import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppfolging.client.digdir_krr.KRRData;
 import no.nav.veilarboppfolging.controller.v2.response.ManuellStatusV2Response;
 import no.nav.veilarboppfolging.controller.v2.response.ManuellV2Response;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirKontaktinfo;
@@ -47,7 +48,7 @@ public class ManuellStatusV3Controller {
 			authService.sjekkLesetilgangMedFnr(manuellStatusRequest.fnr());
 		}
 
-		DigdirKontaktinfo kontaktinfo = manuellStatusService.hentDigdirKontaktinfo(manuellStatusRequest.fnr());
+		KRRData kontaktinfo = manuellStatusService.hentDigdirKontaktinfo(manuellStatusRequest.fnr());
 		boolean erManuell = manuellStatusService.erManuell(manuellStatusRequest.fnr());
 
 		return new ManuellStatusV2Response(

--- a/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
@@ -217,7 +217,7 @@ public class AuthService {
 
     public void sjekkTilgangTilEnhet(String enhetId) {
         if (!harTilgangTilEnhet(enhetId)) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
         }
     }
 

--- a/src/main/java/no/nav/veilarboppfolging/service/ManuellStatusService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/ManuellStatusService.java
@@ -5,9 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppfolging.client.digdir_krr.KRRData;
 import no.nav.veilarboppfolging.client.veilarbarena.VeilarbArenaOppfolging;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirClient;
-import no.nav.veilarboppfolging.client.digdir_krr.DigdirKontaktinfo;
 import no.nav.veilarboppfolging.repository.ManuellStatusRepository;
 import no.nav.veilarboppfolging.repository.OppfolgingsStatusRepository;
 import no.nav.veilarboppfolging.repository.entity.ManuellStatusEntity;
@@ -87,7 +87,7 @@ public class ManuellStatusService {
             return;
         }
 
-        DigdirKontaktinfo digdirKontaktinfo = hentDigdirKontaktinfo(fnr);
+        KRRData digdirKontaktinfo = hentDigdirKontaktinfo(fnr);
 
         if (digdirKontaktinfo.isReservert()) {
             settBrukerTilManuellGrunnetReservertIKRR(aktorId);
@@ -144,7 +144,7 @@ public class ManuellStatusService {
             authService.sjekkTilgangTilEnhet(arenaOppfolging.getNav_kontor());
         }
 
-        DigdirKontaktinfo kontaktinfo = hentDigdirKontaktinfo(fnr);
+        KRRData kontaktinfo = hentDigdirKontaktinfo(fnr);
 
         boolean erUnderOppfolging = oppfolgingService.erUnderOppfolging(aktorId);
         boolean gjeldendeErManuell = erManuell(aktorId);
@@ -163,12 +163,12 @@ public class ManuellStatusService {
         }
     }
 
-    public DigdirKontaktinfo hentDigdirKontaktinfo(Fnr fnr) {
-        return digdirClient.hentKontaktInfo(fnr)
-                .orElseGet(() -> new DigdirKontaktinfo()
-                        .setPersonident(fnr.get())
-                        .setKanVarsles(true)
-                        .setReservert(false));
+    public KRRData hentDigdirKontaktinfo(Fnr fnr) {
+        return digdirClient.hentKontaktInfoV2(fnr)
+                .orElseGet(() -> new KRRData()
+                        .withPersonident(fnr.get())
+                        .withKanVarsles(true)
+                        .withReservert(false));
     }
     private void oppdaterManuellStatus(AktorId aktorId, ManuellStatusEntity manuellStatus) {
         transactor.executeWithoutResult((ignored) -> {

--- a/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
@@ -4,6 +4,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppfolging.client.digdir_krr.KRRData;
 import no.nav.veilarboppfolging.client.veilarbarena.ArenaOppfolgingTilstand;
 import no.nav.veilarboppfolging.client.veilarbarena.VeilarbArenaOppfolging;
 import no.nav.veilarboppfolging.controller.response.UnderOppfolgingDTO;
@@ -288,7 +289,7 @@ public class OppfolgingService {
     public void startOppfolgingHvisIkkeAlleredeStartet(Oppfolgingsbruker oppfolgingsbruker) {
         AktorId aktorId = AktorId.of(oppfolgingsbruker.getAktoerId());
         Fnr fnr = authService.getFnrOrThrow(aktorId);
-        DigdirKontaktinfo kontaktinfo = manuellStatusService.hentDigdirKontaktinfo(fnr);
+        KRRData kontaktinfo = manuellStatusService.hentDigdirKontaktinfo(fnr);
 
         transactor.executeWithoutResult((ignored) -> {
             Optional<OppfolgingEntity> maybeOppfolging = oppfolgingsStatusRepository.hentOppfolging(aktorId);
@@ -372,7 +373,7 @@ public class OppfolgingService {
 
         boolean erManuell = manuellStatusService.erManuell(aktorId);
 
-        DigdirKontaktinfo digdirKontaktinfo = manuellStatusService.hentDigdirKontaktinfo(fnr);
+        KRRData digdirKontaktinfo = manuellStatusService.hentDigdirKontaktinfo(fnr);
 
         // TODO: Burde kanskje heller feile istedenfor å bruke Optional
         Optional<ArenaOppfolgingTilstand> maybeArenaOppfolging = arenaOppfolgingService.hentOppfolgingTilstand(fnr);

--- a/src/test/java/no/nav/veilarboppfolging/client/DigdirClientImplTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/client/DigdirClientImplTest.java
@@ -5,6 +5,7 @@ import no.nav.veilarboppfolging.client.digdir_krr.DigdirClient;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirClientImpl;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirKontaktinfo;
 
+import no.nav.veilarboppfolging.client.digdir_krr.KRRData;
 import no.nav.veilarboppfolging.service.AuthService;
 import no.nav.veilarboppfolging.test.TestUtils;
 
@@ -41,7 +42,7 @@ public class DigdirClientImplTest {
 						.withBody(digdirJson))
 		);
 
-		DigdirKontaktinfo kontaktinfo = digdirClient.hentKontaktInfo(TEST_FNR).orElseThrow();
+		KRRData kontaktinfo = digdirClient.hentKontaktInfo(TEST_FNR).orElseThrow();
 		assertEquals(kontaktinfo.getPersonident(), TEST_FNR.get());
 		assertFalse(kontaktinfo.isKanVarsles());
 		assertTrue(kontaktinfo.isReservert());

--- a/src/test/java/no/nav/veilarboppfolging/client/DigdirClientImplTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/client/DigdirClientImplTest.java
@@ -42,7 +42,7 @@ public class DigdirClientImplTest {
 						.withBody(digdirJson))
 		);
 
-		KRRData kontaktinfo = digdirClient.hentKontaktInfo(TEST_FNR).orElseThrow();
+		KRRData kontaktinfo = digdirClient.hentKontaktInfoV2(TEST_FNR).orElseThrow();
 		assertEquals(kontaktinfo.getPersonident(), TEST_FNR.get());
 		assertFalse(kontaktinfo.isKanVarsles());
 		assertTrue(kontaktinfo.isReservert());
@@ -66,7 +66,7 @@ public class DigdirClientImplTest {
 						.withBody(kodeverkJson))
 		);
 
-		assertTrue(digdirClient.hentKontaktInfo(TEST_FNR).isEmpty());
+		assertTrue(digdirClient.hentKontaktInfoV2(TEST_FNR).isEmpty());
 	}
 
 

--- a/src/test/java/no/nav/veilarboppfolging/config/ClientTestConfig.java
+++ b/src/test/java/no/nav/veilarboppfolging/config/ClientTestConfig.java
@@ -11,6 +11,8 @@ import no.nav.common.types.identer.Fnr;
 import no.nav.veilarboppfolging.client.behandle_arbeidssoker.BehandleArbeidssokerClient;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirClient;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirKontaktinfo;
+import no.nav.veilarboppfolging.client.digdir_krr.KRRData;
+import no.nav.veilarboppfolging.client.digdir_krr.KRRKontaktInfoV3;
 import no.nav.veilarboppfolging.client.veilarbarena.ArenaOppfolging;
 import no.nav.veilarboppfolging.client.veilarbarena.VeilarbArenaOppfolging;
 import no.nav.veilarboppfolging.client.veilarbarena.VeilarbarenaClient;
@@ -104,7 +106,12 @@ public class ClientTestConfig {
     public DigdirClient digdirClient() {
         return new DigdirClient() {
             @Override
-            public Optional<DigdirKontaktinfo> hentKontaktInfo(Fnr fnr) {
+            public Optional<KRRData> hentKontaktInfo(Fnr fnr) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<KRRData> hentKontaktInfoV2(Fnr fnr) {
                 return Optional.empty();
             }
 

--- a/src/test/java/no/nav/veilarboppfolging/controller/v3/ManuellStatusV3ControllerTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/v3/ManuellStatusV3ControllerTest.java
@@ -3,6 +3,7 @@ package no.nav.veilarboppfolging.controller.v3;
 import no.nav.common.json.JsonUtils;
 import no.nav.common.types.identer.Fnr;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirKontaktinfo;
+import no.nav.veilarboppfolging.client.digdir_krr.KRRData;
 import no.nav.veilarboppfolging.controller.v3.request.ManuellStatusRequest;
 import no.nav.veilarboppfolging.service.AuthService;
 import no.nav.veilarboppfolging.service.ManuellStatusService;
@@ -49,7 +50,7 @@ public class ManuellStatusV3ControllerTest {
     public void manuell_hent_status_skal_returnere_riktig() throws Exception {
         when(manuellStatusService.erManuell((Fnr) any())).thenReturn(true);
         String expJson = "{\"erUnderManuellOppfolging\":true}, \"krrStatus\":{\"kanVarsles\":true, \"erReservert\":false}";
-        when(manuellStatusService.hentDigdirKontaktinfo(manuellStatusRequest.fnr())).thenReturn(new DigdirKontaktinfo().setReservert(false).setKanVarsles(true));
+        when(manuellStatusService.hentDigdirKontaktinfo(manuellStatusRequest.fnr())).thenReturn(new KRRData().withReservert(false).withKanVarsles(true));
 
         mockMvc.perform(post("/api/v3/manuell/hent-status")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/no/nav/veilarboppfolging/service/AktiverBrukerIntegrationTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/AktiverBrukerIntegrationTest.java
@@ -4,6 +4,7 @@ import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
 import no.nav.veilarboppfolging.client.behandle_arbeidssoker.BehandleArbeidssokerClient;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirKontaktinfo;
+import no.nav.veilarboppfolging.client.digdir_krr.KRRData;
 import no.nav.veilarboppfolging.controller.request.Innsatsgruppe;
 import no.nav.veilarboppfolging.domain.Oppfolging;
 import no.nav.veilarboppfolging.repository.*;
@@ -79,7 +80,7 @@ public class AktiverBrukerIntegrationTest {
 
         DbTestUtils.cleanupTestDb();
         when(authService.getAktorIdOrThrow(any(Fnr.class))).thenReturn(AKTOR_ID);
-        when(manuellStatusService.hentDigdirKontaktinfo(any())).thenReturn(new DigdirKontaktinfo());
+        when(manuellStatusService.hentDigdirKontaktinfo(any())).thenReturn(new KRRData());
     }
 
     @Test

--- a/src/test/java/no/nav/veilarboppfolging/service/ManuellStatusServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/ManuellStatusServiceTest.java
@@ -82,7 +82,7 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
     public void oppdaterManuellStatus_oppretter_manuell_status_og_publiserer_paa_kafka_ved_oppdatering_av_manuell_status() {
         when(oppfolgingService.erUnderOppfolging(AKTOR_ID)).thenReturn(true);
         when(authService.harTilgangTilEnhet(any())).thenReturn(true);
-        when(digdirClient.hentKontaktInfo(FNR)).thenReturn(Optional.of(new KRRData()));
+        when(digdirClient.hentKontaktInfoV2(FNR)).thenReturn(Optional.of(new KRRData()));
         gittAktivOppfolging();
 
         String begrunnelse = "test begrunnelse";
@@ -131,7 +131,7 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
 
         when(oppfolgingService.erUnderOppfolging(AKTOR_ID)).thenReturn(true);
 
-        when(digdirClient.hentKontaktInfo(FNR)).thenReturn(Optional.of(kontaktinfo));
+        when(digdirClient.hentKontaktInfoV2(FNR)).thenReturn(Optional.of(kontaktinfo));
 
         gittAktivOppfolging();
 
@@ -166,7 +166,7 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
 
         when(oppfolgingService.erUnderOppfolging(AKTOR_ID)).thenReturn(true);
         when(authService.harTilgangTilEnhet(any())).thenReturn(true);
-        when(digdirClient.hentKontaktInfo(FNR)).thenReturn(Optional.of(kontaktinfo));
+        when(digdirClient.hentKontaktInfoV2(FNR)).thenReturn(Optional.of(kontaktinfo));
 
         manuellStatusService.synkroniserManuellStatusMedDigdir(FNR);
 
@@ -187,7 +187,7 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
         String opprettetAvBruker = "test opprettet av";
         gittAktivOppfolging();
         when(authService.harTilgangTilEnhet(any())).thenReturn(true);
-        when(digdirClient.hentKontaktInfo(FNR)).thenReturn(Optional.of(kontaktinfo));
+        when(digdirClient.hentKontaktInfoV2(FNR)).thenReturn(Optional.of(kontaktinfo));
         manuellStatusService.oppdaterManuellStatus(FNR, true, begrunnelse, SYSTEM, opprettetAvBruker);
 
         manuellStatusService.synkroniserManuellStatusMedDigdir(FNR);
@@ -261,14 +261,14 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
                 .withEpostadresse("email")
                 .withMobiltelefonnummer("12345");
 
-        when(digdirClient.hentKontaktInfo(FNR)).thenReturn(Optional.of(kontaktinfo));
+        when(digdirClient.hentKontaktInfoV2(FNR)).thenReturn(Optional.of(kontaktinfo));
 
         assertEquals(kontaktinfo, manuellStatusService.hentDigdirKontaktinfo(FNR));
     }
 
     @Test
     public void hentDigdirKontaktinfo__skal_returnere_fallback_hvis_digdir_mangler_kontaktinfo() {
-        when(digdirClient.hentKontaktInfo(FNR)).thenReturn(Optional.empty());
+        when(digdirClient.hentKontaktInfoV2(FNR)).thenReturn(Optional.empty());
 
         KRRData fallbackKontaktInfo = new KRRData()
                 .withPersonident(FNR.get())

--- a/src/test/java/no/nav/veilarboppfolging/service/ManuellStatusServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/ManuellStatusServiceTest.java
@@ -2,6 +2,7 @@ package no.nav.veilarboppfolging.service;
 
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
+import no.nav.veilarboppfolging.client.digdir_krr.KRRData;
 import no.nav.veilarboppfolging.client.veilarbarena.VeilarbArenaOppfolging;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirClient;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirKontaktinfo;
@@ -81,7 +82,7 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
     public void oppdaterManuellStatus_oppretter_manuell_status_og_publiserer_paa_kafka_ved_oppdatering_av_manuell_status() {
         when(oppfolgingService.erUnderOppfolging(AKTOR_ID)).thenReturn(true);
         when(authService.harTilgangTilEnhet(any())).thenReturn(true);
-        when(digdirClient.hentKontaktInfo(FNR)).thenReturn(Optional.of(new DigdirKontaktinfo()));
+        when(digdirClient.hentKontaktInfo(FNR)).thenReturn(Optional.of(new KRRData()));
         gittAktivOppfolging();
 
         String begrunnelse = "test begrunnelse";
@@ -121,12 +122,12 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
 
     @Test
     public void synkroniserManuellStatusMedDigDir__skal_lage_manuell_status_hvis_reservert() {
-        DigdirKontaktinfo kontaktinfo = new DigdirKontaktinfo()
-                .setPersonident(FNR.get())
-                .setKanVarsles(true)
-                .setReservert(true)
-                .setEpostadresse("email")
-                .setMobiltelefonnummer("12345");
+        KRRData kontaktinfo = new KRRData()
+                .withPersonident(FNR.get())
+                .withKanVarsles(true)
+                .withReservert(true)
+                .withEpostadresse("email")
+                .withMobiltelefonnummer("12345");
 
         when(oppfolgingService.erUnderOppfolging(AKTOR_ID)).thenReturn(true);
 
@@ -156,12 +157,12 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
 
     @Test
     public void synkroniserManuellStatusMedDigDir__skal_ikke_lage_manuell_status_hvis_ikke_reservert_nar_vi_ikke_har_status_pa_bruker_fra_for() {
-        DigdirKontaktinfo kontaktinfo = new DigdirKontaktinfo()
-                .setPersonident(FNR.get())
-                .setKanVarsles(true)
-                .setReservert(false)
-                .setEpostadresse("email")
-                .setMobiltelefonnummer("12345");
+        KRRData kontaktinfo = new KRRData()
+                .withPersonident(FNR.get())
+                .withKanVarsles(true)
+                .withReservert(false)
+                .withEpostadresse("email")
+                .withMobiltelefonnummer("12345");
 
         when(oppfolgingService.erUnderOppfolging(AKTOR_ID)).thenReturn(true);
         when(authService.harTilgangTilEnhet(any())).thenReturn(true);
@@ -176,12 +177,12 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
 
     @Test
     public void synkroniserManuellStatusMedDigDir__skal_lage_manuell_status_hvis_ikke_reservert_nar_vi_har_status_pa_bruker_fra_for() {
-        DigdirKontaktinfo kontaktinfo = new DigdirKontaktinfo()
-                .setPersonident(FNR.get())
-                .setKanVarsles(true)
-                .setReservert(false)
-                .setEpostadresse("email")
-                .setMobiltelefonnummer("12345");
+        KRRData kontaktinfo = new KRRData()
+                .withPersonident(FNR.get())
+                .withKanVarsles(true)
+                .withReservert(false)
+                .withEpostadresse("email")
+                .withMobiltelefonnummer("12345");
         String begrunnelse = "test begrunnelse";
         String opprettetAvBruker = "test opprettet av";
         gittAktivOppfolging();
@@ -253,12 +254,12 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
 
     @Test
     public void hentDigDirKontaktinfo__skal_returnere_kontaktinfo_fra_digDir() {
-        DigdirKontaktinfo kontaktinfo = new DigdirKontaktinfo()
-                .setPersonident(FNR.get())
-                .setKanVarsles(true)
-                .setReservert(true)
-                .setEpostadresse("email")
-                .setMobiltelefonnummer("12345");
+        KRRData kontaktinfo = new KRRData()
+                .withPersonident(FNR.get())
+                .withKanVarsles(true)
+                .withReservert(true)
+                .withEpostadresse("email")
+                .withMobiltelefonnummer("12345");
 
         when(digdirClient.hentKontaktInfo(FNR)).thenReturn(Optional.of(kontaktinfo));
 
@@ -269,10 +270,10 @@ public class ManuellStatusServiceTest extends IsolatedDatabaseTest {
     public void hentDigdirKontaktinfo__skal_returnere_fallback_hvis_digdir_mangler_kontaktinfo() {
         when(digdirClient.hentKontaktInfo(FNR)).thenReturn(Optional.empty());
 
-        DigdirKontaktinfo fallbackKontaktInfo = new DigdirKontaktinfo()
-                .setPersonident(FNR.get())
-                .setKanVarsles(true)
-                .setReservert(false);
+        KRRData fallbackKontaktInfo = new KRRData()
+                .withPersonident(FNR.get())
+                .withKanVarsles(true)
+                .withReservert(false);
 
         assertEquals(fallbackKontaktInfo, manuellStatusService.hentDigdirKontaktinfo(FNR));
     }

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
@@ -10,6 +10,7 @@ import no.nav.tjeneste.virksomhet.ytelseskontrakt.v3.informasjon.ytelseskontrakt
 import no.nav.tjeneste.virksomhet.ytelseskontrakt.v3.meldinger.HentYtelseskontraktListeRequest;
 import no.nav.tjeneste.virksomhet.ytelseskontrakt.v3.meldinger.HentYtelseskontraktListeResponse;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirKontaktinfo;
+import no.nav.veilarboppfolging.client.digdir_krr.KRRData;
 import no.nav.veilarboppfolging.client.veilarbarena.ArenaOppfolgingTilstand;
 import no.nav.veilarboppfolging.client.veilarbarena.VeilarbArenaOppfolging;
 import no.nav.veilarboppfolging.client.ytelseskontrakt.YtelseskontraktClient;
@@ -99,7 +100,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
 
         when(arenaOppfolgingService.hentOppfolgingTilstand(FNR)).thenReturn(Optional.of(arenaOppfolgingTilstand));
         when(ytelseskontraktClient.hentYtelseskontraktListe(any())).thenReturn(mock(YtelseskontraktResponse.class));
-        when(manuellStatusService.hentDigdirKontaktinfo(FNR)).thenReturn(new DigdirKontaktinfo());
+        when(manuellStatusService.hentDigdirKontaktinfo(FNR)).thenReturn(new KRRData());
     }
 
     @Test
@@ -375,10 +376,10 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
     }
 
     private void gittReservasjonIKrr(boolean reservert) {
-        DigdirKontaktinfo kontaktinfo = new DigdirKontaktinfo();
-        kontaktinfo.setPersonident("fnr");
-        kontaktinfo.setKanVarsles(false);
-        kontaktinfo.setReservert(reservert);
+        KRRData kontaktinfo = new KRRData()
+            .withPersonident("fnr")
+            .withKanVarsles(false)
+            .withReservert(reservert);
 
         when(manuellStatusService.hentDigdirKontaktinfo(FNR)).thenReturn(kontaktinfo);
     }

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest2.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest2.java
@@ -5,6 +5,8 @@ import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirClient;
 import no.nav.veilarboppfolging.client.digdir_krr.DigdirKontaktinfo;
+import no.nav.veilarboppfolging.client.digdir_krr.KRRData;
+import no.nav.veilarboppfolging.client.digdir_krr.KRRKontaktInfoV3;
 import no.nav.veilarboppfolging.domain.Oppfolging;
 import no.nav.veilarboppfolging.repository.*;
 import no.nav.veilarboppfolging.repository.entity.MaalEntity;
@@ -77,7 +79,12 @@ public class OppfolgingServiceTest2 extends IsolatedDatabaseTest {
 
         DigdirClient digdirClient = new DigdirClient() {
             @Override
-            public Optional<DigdirKontaktinfo> hentKontaktInfo(Fnr fnr) {
+            public Optional<KRRData> hentKontaktInfo(Fnr fnr) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<KRRData> hentKontaktInfoV2(Fnr fnr) {
                 return Optional.empty();
             }
 

--- a/src/test/resources/client/digdir/kontaktinfo.json
+++ b/src/test/resources/client/digdir/kontaktinfo.json
@@ -1,14 +1,18 @@
 {
-  "personident": "12345678900",
+  "personidentifikator": "12345678900",
   "aktiv": true,
-  "kanVarsles": false,
-  "reservert": true,
+  "reservasjon": "JA",
+  "reservasjonstidspunkt": null,
+  "status": "AKTIV",
+  "varslingsstatus": "KAN_IKKE_VARSLES",
+  "kontaktinformasjon": {
+    "epostadresse": "noreply@nav.no",
+    "mobiltelefonnummer": "11111111",
+    "mobiltelefonnummerOppdatert": "2023-03-30T22:00:00Z",
+    "mobiltelefonnummerVerifisert": "2023-03-30T22:00:00Z",
+    "epostadresseOppdatert": "2023-03-30T22:00:00Z",
+    "epostadresseVerifisert": "2023-03-30T22:00:00Z"
+  },
   "spraak": "nb",
-  "spraakOppdatert": "2023-03-30T22:00:00Z",
-  "epostadresse": "noreply@nav.no",
-  "epostadresseOppdatert": "2023-03-30T22:00:00Z",
-  "epostadresseVerifisert": "2023-03-30T22:00:00Z",
-  "mobiltelefonnummer": "11111111",
-  "mobiltelefonnummerOppdatert": "2023-03-30T22:00:00Z",
-  "mobiltelefonnummerVerifisert": "2023-03-30T22:00:00Z"
+  "spraakOppdatert": "2023-03-30T22:00:00Z"
 }


### PR DESCRIPTION
Vi bruker idag en gammel versjon endepunktet /person hvor feltene ikke er så godt dokumentert. Feltene fra det nye endeunktet kan man finne på https://docs.digdir.no/docs/Kontaktregisteret/krr_attributter
- Tar i bruk v2 av /person endepunktet fra KRR, noen felter har fått litt andre navn og man har mulighet for å se status på personen i registrert (AKTIV, SLETTET, IKKE_REGISTRERT)
- Mapper til "intern"-domene klasse istedetfor å gå rett på DTO fra KRR