### PR TITLE
Slett ubrukte  start-oppfolging endepunkter

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/controller/OppfolgingController.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/OppfolgingController.java
@@ -47,12 +47,6 @@ public class OppfolgingController {
         return tilDto(oppfolgingService.hentOppfolgingsStatus(fodselsnummer), authService.erInternBruker());
     }
 
-    @PostMapping("/startOppfolging")
-    public OppfolgingStatus startOppfolging(@RequestParam("fnr") Fnr fnr) {
-        authService.skalVereInternBruker();
-        return tilDto(oppfolgingService.startOppfolging(fnr), authService.erInternBruker());
-    }
-
     @GetMapping("/avslutningStatus")
     public AvslutningStatus hentAvslutningStatus(@RequestParam("fnr") Fnr fnr) {
         authService.skalVereInternBruker();

--- a/src/main/java/no/nav/veilarboppfolging/controller/v2/OppfolgingV2Controller.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/v2/OppfolgingV2Controller.java
@@ -54,13 +54,6 @@ public class OppfolgingV2Controller {
         return new UnderOppfolgingV2Response(oppfolgingService.erUnderOppfolging(fnr));
     }
 
-    @PostMapping("/start")
-    public ResponseEntity<?> startOppfolging(@RequestParam("fnr") Fnr fnr) {
-        authService.skalVereInternBruker();
-        oppfolgingService.startOppfolging(fnr);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
-
     @PostMapping("/avslutt")
     public ResponseEntity<?> avsluttOppfolging(@RequestBody AvsluttOppfolgingV2Request request) {
         authService.skalVereInternBruker();

--- a/src/main/java/no/nav/veilarboppfolging/controller/v3/OppfolgingV3Controller.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/v3/OppfolgingV3Controller.java
@@ -57,13 +57,6 @@ public class OppfolgingV3Controller {
         return tilDto(oppfolgingService.hentOppfolgingsStatus(fodselsnummer), authService.erInternBruker());
     }
 
-    @PostMapping("/oppfolging/start")
-    public ResponseEntity<?> startOppfolging(@RequestBody OppfolgingRequest oppfolgingRequest) {
-        authService.skalVereInternBruker();
-        oppfolgingService.startOppfolging(oppfolgingRequest.fnr());
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
-
     @PostMapping("/oppfolging/hent-avslutning-status")
     public AvslutningStatus hentAvslutningStatus(@RequestBody OppfolgingRequest oppfolgingRequest) {
         authService.skalVereInternBruker();

--- a/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/OppfolgingService.java
@@ -123,24 +123,6 @@ public class OppfolgingService {
     }
 
     @SneakyThrows
-    public OppfolgingStatusData startOppfolging(Fnr fnr) {
-        AktorId aktorId = authService.getAktorIdOrThrow(fnr);
-
-        authService.sjekkLesetilgangMedFnr(fnr);
-
-        ArenaOppfolgingTilstand arenaOppfolgingTilstand = arenaOppfolgingService.hentOppfolgingTilstand(fnr)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR));
-
-        authService.sjekkTilgangTilEnhet(arenaOppfolgingTilstand.getOppfolgingsenhet());
-
-        if (ArenaUtils.kanSettesUnderOppfolging(arenaOppfolgingTilstand, erUnderOppfolging(aktorId))) {
-            startOppfolgingHvisIkkeAlleredeStartet(aktorId);
-        }
-
-        return getOppfolgingStatusData(fnr);
-    }
-
-    @SneakyThrows
     public AvslutningStatusData avsluttOppfolging(Fnr fnr, String veilederId, String begrunnelse) {
         AktorId aktorId = authService.getAktorIdOrThrow(fnr);
 

--- a/src/test/java/no/nav/veilarboppfolging/controller/v3/OppfolgingV3ControllerTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/v3/OppfolgingV3ControllerTest.java
@@ -126,14 +126,6 @@ class OppfolgingV3ControllerTest {
     }
 
     @Test
-    void startOppfolging_skal_returnere_tom_respons() throws Exception {
-        mockMvc.perform(post("/api/v3/oppfolging/start")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"fnr\":\"12345678900\"}")
-        ).andExpect(status().is(204));
-    }
-
-    @Test
     void hentAvslutningStatus_skal_returnere_avslutningstatus() throws Exception {
         when(oppfolgingService.hentAvslutningStatus(TEST_FNR)).thenReturn(
                 AvslutningStatusData.builder()

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
@@ -107,18 +107,13 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
     public void skal_publisere_paa_kafka_ved_start_paa_oppfolging() {
         arenaOppfolgingTilstand.setFormidlingsgruppe("IARBS");
         oppfolgingsStatusRepository.opprettOppfolging(AKTOR_ID);
-
-        when(kvpService.erUnderKvp(anyLong())).thenReturn(false);
-
         assertTrue(oppfolgingsPeriodeRepository.hentOppfolgingsperioder(AKTOR_ID).isEmpty());
 
         oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(AKTOR_ID);
-
         assertUnderOppfolgingLagret(AKTOR_ID);
 
         List<OppfolgingsperiodeEntity> oppfolgingsperioder = oppfolgingsPeriodeRepository.hentOppfolgingsperioder(AKTOR_ID);
         assertEquals(1, oppfolgingsperioder.size());
-
         verify(kafkaProducerService, times(1)).publiserOppfolgingsperiode(any(SisteOppfolgingsperiodeV1.class));
     }
 

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
@@ -112,7 +112,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
 
         assertTrue(oppfolgingsPeriodeRepository.hentOppfolgingsperioder(AKTOR_ID).isEmpty());
 
-        oppfolgingService.startOppfolging(FNR);
+        oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(AKTOR_ID);
 
         assertUnderOppfolgingLagret(AKTOR_ID);
 
@@ -126,7 +126,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
     public void skal_publisere_paa_kafka_ved_avsluttet_oppfolging() {
         arenaOppfolgingTilstand.setFormidlingsgruppe("IARBS");
         oppfolgingsStatusRepository.opprettOppfolging(AKTOR_ID);
-        oppfolgingService.startOppfolging(FNR);
+        oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(AKTOR_ID);
 
         assertUnderOppfolgingLagret(AKTOR_ID);
 
@@ -147,7 +147,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
         when(authService.harTilgangTilEnhet(any())).thenReturn(false);
         doCallRealMethod().when(authService).sjekkTilgangTilEnhet(any());
 
-        oppfolgingService.startOppfolging(FNR);
+        oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(AKTOR_ID);
     }
 
     @Test(expected = ResponseStatusException.class)

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
@@ -143,15 +143,6 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
 
     @Test(expected = ResponseStatusException.class)
     @SneakyThrows
-    public void start_oppfolging_uten_enhet_tilgang() {
-        when(authService.harTilgangTilEnhet(any())).thenReturn(false);
-        doCallRealMethod().when(authService).sjekkTilgangTilEnhet(any());
-
-        oppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(AKTOR_ID);
-    }
-
-    @Test(expected = ResponseStatusException.class)
-    @SneakyThrows
     public void avslutt_oppfolging_uten_enhet_tilgang() {
         when(authService.harTilgangTilEnhet(any())).thenReturn(false);
         doCallRealMethod().when(authService).sjekkTilgangTilEnhet(any());


### PR DESCRIPTION
Sletter følgende endepunkt:
Finner ikke noe bruk av dem i loggene siste 30 dager
- `POST` `/api/oppfolging/startOppfolging`
- `POST` `/api/v2/oppfolging/start`
- `POST` `/api/v3/oppfolging/start`