### PR TITLE
Gi SELECT-rettigheter på veilarboppfolging-schema til cloudsqliamuser

### DIFF
--- a/src/main/resources/db/migration/V5__give-select-grant-for-cloudsqliamuser.sql
+++ b/src/main/resources/db/migration/V5__give-select-grant-for-cloudsqliamuser.sql
@@ -3,7 +3,8 @@ $$
     BEGIN
         IF (SELECT exists(SELECT rolname FROM pg_roles WHERE rolname = 'cloudsqliamuser'))
         THEN
-            GRANT SELECT ON ALL TABLES IN SCHEMA veilarboppfolging TO cloudsqliamuser;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA veilarboppfolging GRANT SELECT ON TABLES TO "cloudsqliamuser";
+            GRANT SELECT ON ALL TABLES IN SCHEMA veilarboppfolging TO "cloudsqliamuser";
         END IF;
     END
 $$;

--- a/src/main/resources/db/migration/V5__give-select-grant-for-cloudsqliamuser.sql
+++ b/src/main/resources/db/migration/V5__give-select-grant-for-cloudsqliamuser.sql
@@ -1,0 +1,9 @@
+DO
+$$
+    BEGIN
+        IF (SELECT exists(SELECT rolname FROM pg_roles WHERE rolname = 'cloudsqliamuser'))
+        THEN
+            GRANT SELECT ON ALL TABLES IN SCHEMA veilarboppfolging TO cloudsqliamuser;
+        END IF;
+    END
+$$;


### PR DESCRIPTION
`nais postgres prepare veilarboppfolging` gir berre rettigheiter på `public`-schema. Inntil [støtte for custom-schema er på plass](https://github.com/nais/cli/issues/435) må vi sette dette sjølve.