### PR TITLE
Gir amt-aktivitetskort-publisher tilgang til å hente gjeldende oppfølgingsperiode

### DIFF
--- a/nais-dev-gcp.yaml
+++ b/nais-dev-gcp.yaml
@@ -180,6 +180,9 @@ spec:
         - application: amt-person-service
           namespace: amt
           cluster: dev-gcp
+        - application: amt-aktivitetskort-publisher
+          namespace: amt
+          cluster: dev-gcp
         - application: tms-min-side-proxy
           namespace: min-side
           cluster: dev-gcp

--- a/nais-prod-gcp.yaml
+++ b/nais-prod-gcp.yaml
@@ -187,6 +187,9 @@ spec:
         - application: amt-person-service
           namespace: amt
           cluster: prod-gcp
+        - application: amt-aktivitetskort-publisher
+          namespace: amt
+          cluster: prod-gcp
         - application: tms-min-side-proxy
           namespace: min-side
           cluster: prod-gcp

--- a/src/main/java/no/nav/veilarboppfolging/utils/auth/AllowListApplicationName.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/auth/AllowListApplicationName.java
@@ -10,6 +10,7 @@ public class AllowListApplicationName {
     public static final String VEILARBREGISTRERING = "veilarbregistrering";
     public static final String VEILARBPORTEFOLJE = "veilarbportefolje";
     public static final String AMT_PERSON_SERVICE = "amt-person-service";
+    public static final String AMT_AKTIVITETSKORT_PUBLISHER = "amt-aktivitetskort-publisher";
     public static final String VEILARBPERSONFLATE = "veilarbpersonflate";
     public static final String INNGAR = "inngar";
     public static final String VEILARBDIRIGENT = "veilarbdirigent";

--- a/src/main/kotlin/no/nav/veilarboppfolging/controller/OppfolgingV3Controller.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/controller/OppfolgingV3Controller.kt
@@ -80,7 +80,8 @@ class OppfolgingV3Controller(
             AllowListApplicationName.VEILARBVEDTAKSSTOTTE,
             AllowListApplicationName.VEILARBDIALOG,
             AllowListApplicationName.VEILARBAKTIVITET,
-            AllowListApplicationName.MULIGHETSROMMET
+            AllowListApplicationName.MULIGHETSROMMET,
+            AllowListApplicationName.AMT_AKTIVITETSKORT_PUBLISHER
         )
         authService.authorizeRequest(oppfolgingRequest.fnr, allowlist)
         return oppfolgingService.hentGjeldendeOppfolgingsperiode(oppfolgingRequest.fnr)


### PR DESCRIPTION
`amt-aktivitetskort-publisher` må lagre gjeldende oppfølgingsperiode for å avgjøre når det skal opprettes nye aktivitetskort i aktivitetsplanen

ref: https://trello.com/c/5Sm6ICfw/2188-bug-opprette-aktivitetskort-p%C3%A5-deltaker-i-ny-oppf%C3%B8lgingsperiode