### PR TITLE
Legg til sist tilordnet dato for veileder

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/controller/AdminController.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/AdminController.java
@@ -75,6 +75,7 @@ public class AdminController {
         return new Veilarbportefoljeinfo().setVeilederId(tilordningEntity.map(VeilederTilordningEntity::getVeilederId).map(NavIdent::of).orElse(null))
                 .setErUnderOppfolging(tilordningEntity.map(VeilederTilordningEntity::isOppfolging).orElse(false))
                 .setNyForVeileder(tilordningEntity.map(VeilederTilordningEntity::isNyForVeileder).orElse(false))
+                .setSistTilordnetDato(tilordningEntity.map(VeilederTilordningEntity::getSistTilordnet).orElse(null))
                 .setErManuell(erManuell)
                 .setStartDato(startDato);
     }

--- a/src/main/java/no/nav/veilarboppfolging/controller/response/Veilarbportefoljeinfo.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/response/Veilarbportefoljeinfo.java
@@ -17,4 +17,5 @@ public class Veilarbportefoljeinfo {
     private boolean nyForVeileder;
     private boolean erManuell;
     private ZonedDateTime startDato;
+    private ZonedDateTime sistTilordnetDato;
 }


### PR DESCRIPTION
Sender med dato for sist tilordnet veileder i admin endepunktet for veilarbportefolje. Dette trengs for å kunne vise dato i egen kolonne i frontenden. 