### PR TITLE
La eksterne brukere sette seg selv under oppfølging

### DIFF
--- a/src/main/kotlin/no/nav/veilarboppfolging/controller/OppfolgingV3Controller.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/controller/OppfolgingV3Controller.kt
@@ -187,10 +187,15 @@ class OppfolgingV3Controller(
 
     @PostMapping("/oppfolging/startOppfolgingsperiode")
     fun aktiverBruker(@RequestBody startOppfolging: StartOppfolgingDto): ResponseEntity<RegistrerIkkeArbeidssokerDto> {
-        authService.skalVereInternBruker()
+        val fnrTilNyBruker = if (authService.erEksternBruker()) {
+            authService.hentInnloggetPersonIdent()?.let {  Fnr.of(it) }
+                ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Kan ikke hente innlogget personident")
+        } else {
+            authService.skalVereInternBruker()
+            startOppfolging.fnr ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "fnr er påkrevd for interne brukere")
+        }
         authService.sjekkAtApplikasjonErIAllowList(ALLOWLIST)
-
-        val arenaResponse = arenaOppfolgingService.registrerIkkeArbeidssoker(startOppfolging.fnr)
+        val arenaResponse = arenaOppfolgingService.registrerIkkeArbeidssoker(fnrTilNyBruker)
         when (arenaResponse) {
             is RegistrerIArenaSuccess -> {
                 when (arenaResponse.arenaResultat.kode) {
@@ -201,7 +206,7 @@ class OppfolgingV3Controller(
                     else -> {
                         logger.info("Bruker registrert i Arena med resultat: ${arenaResponse.arenaResultat.kode}")
                         aktiverBrukerManueltService.aktiverBrukerManuelt(
-                            fnr = startOppfolging.fnr,
+                            fnr = fnrTilNyBruker,
                             kontorSattAvVeileder = startOppfolging.kontorSattAvVeileder,
                         )
                         return ResponseEntity(arenaResponse.arenaResultat, HttpStatus.OK)
@@ -243,7 +248,7 @@ class OppfolgingV3Controller(
 }
 
 class StartOppfolgingDto(
-    val fnr: Fnr,
+    val fnr: Fnr?,
     val henviserSystem: HenviserSystem,
     val kontorSattAvVeileder: String?
 )

--- a/src/test/java/no/nav/veilarboppfolging/controller/v3/OppfolgingV3ControllerTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/v3/OppfolgingV3ControllerTest.java
@@ -302,7 +302,7 @@ class OppfolgingV3ControllerTest {
     }
 
     @Test
-    void startOppfolgingsperiode_skal_returnere_400_ved_manglende_fnr() throws Exception {
+    void startOppfolgingsperiode_skal_returnere_400_ved_manglende_fnr_hvis_intern_bruker() throws Exception {
         when(arenaOppfolgingService.registrerIkkeArbeidssoker(TEST_FNR))
                 .thenReturn(new RegistrerIArenaSuccess(new RegistrerIkkeArbeidssokerDto("Ny bruker ble registrert ok som IARBS", ArenaRegistreringResultat.BRUKER_ALLEREDE_ARBS)));
         mockMvc.perform(post("/api/v3/oppfolging/startOppfolgingsperiode")
@@ -310,6 +310,20 @@ class OppfolgingV3ControllerTest {
                         .content("{\"henviserSystem\":\"AAP\"}")
                 )
                 .andExpect(status().is(400));
+    }
+
+    @Test
+    void startOppfolgingsperiode_skal_fungere_for_eksterne_brukere() throws Exception {
+        when(arenaOppfolgingService.registrerIkkeArbeidssoker(TEST_FNR))
+                .thenReturn(new RegistrerIArenaSuccess(new RegistrerIkkeArbeidssokerDto("Ny bruker ble registrert ok som IARBS", ArenaRegistreringResultat.BRUKER_ALLEREDE_ARBS)));
+        when(authService.erEksternBruker()).thenReturn(true);
+        when(authService.hentInnloggetPersonIdent()).thenReturn("12345678900");
+        mockMvc.perform(post("/api/v3/oppfolging/startOppfolgingsperiode")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"henviserSystem\":\"AAP\"}")
+                )
+                .andExpect(content().string("{\"resultat\":\"Ny bruker ble registrert ok som IARBS\",\"kode\":\"BRUKER_ALLEREDE_ARBS\"}"))
+                .andExpect(status().is(200));
     }
 
     @Test


### PR DESCRIPTION
Mange måter å løse dette på. Usikker på om det er best å lage to separate endepunkter, en for interne brukere og en for eksterne slik at typing av input blir litt tydeligere, eller om det er greit å ha ett endepunkt for begge brukstilfellene. 