### PR TITLE
Bruk veilarbarena endepunkter uten 404 når bruker ikke finnes

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/client/veilarbarena/ArenaOppfolgingTilstand.java
+++ b/src/main/java/no/nav/veilarboppfolging/client/veilarbarena/ArenaOppfolgingTilstand.java
@@ -26,8 +26,8 @@ public class ArenaOppfolgingTilstand {
         return new ArenaOppfolgingTilstand(
                 veilarbArenaOppfolgingsBruker.getFormidlingsgruppekode(),
                 veilarbArenaOppfolgingsBruker.getKvalifiseringsgruppekode(),
-                veilarbArenaOppfolgingsBruker.getNav_kontor(),
-                Optional.ofNullable(veilarbArenaOppfolgingsBruker.getIserv_fra_dato()).map(ZonedDateTime::toLocalDate).orElse(null)
+                veilarbArenaOppfolgingsBruker.getNavKontor(),
+                Optional.ofNullable(veilarbArenaOppfolgingsBruker.getIservFraDato()).map(ZonedDateTime::toLocalDate).orElse(null)
         );
     }
 

--- a/src/main/java/no/nav/veilarboppfolging/client/veilarbarena/VeilarbArenaOppfolgingsBruker.java
+++ b/src/main/java/no/nav/veilarboppfolging/client/veilarbarena/VeilarbArenaOppfolgingsBruker.java
@@ -6,7 +6,7 @@ import lombok.experimental.Accessors;
 import java.time.ZonedDateTime;
 
 /**
- * Har IKKE feltet kanReaktiveres eller iservFraDato som oppfølgingsStatus {@link no.nav.veilarboppfolging.client.veilarbarena.VeilarbArenaOppfolgingsStatus} har, men har hovedmaalkode
+ * Har IKKE feltet kanReaktiveres som oppfølgingsStatus {@link no.nav.veilarboppfolging.client.veilarbarena.VeilarbArenaOppfolgingsStatus} har, men har hovedmaalkode
  * @see no.nav.veilarboppfolging.client.veilarbarena.VeilarbArenaOppfolgingsStatus
  */
 @Data
@@ -14,9 +14,16 @@ import java.time.ZonedDateTime;
 public class VeilarbArenaOppfolgingsBruker {
     String fodselsnr;
     String formidlingsgruppekode;
+    ZonedDateTime iservFraDato;
+    String navKontor;
     String kvalifiseringsgruppekode;
     String rettighetsgruppekode;
-    ZonedDateTime iserv_fra_dato;
     String hovedmaalkode;
-    String nav_kontor;
+    String sikkerhetstiltakTypeKode;
+    String frKode;
+    Boolean harOppfolgingssak;
+    Boolean sperretAnsatt;
+    Boolean erDoed;
+    ZonedDateTime doedFraDato;
+    ZonedDateTime sistEndretDato;
 }

--- a/src/main/kotlin/no/nav/veilarboppfolging/client/veilarbarena/VeilarbarenaClientImpl.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/client/veilarbarena/VeilarbarenaClientImpl.kt
@@ -69,7 +69,7 @@ class VeilarbarenaClientImpl(
             is TokenResult.Success -> {
                 val request = buildRequest(url, payload, tokenResult.token)
                 client.newCall(request).execute().use { response ->
-                    if (response.code == 404) {
+                    if (response.code == 404 || response.code == 204) {
                         return RequestResult.Success(Optional.empty())
                     }
                     /* Kun forventet å få 422 på registrer endepunkt, da ser body lik ut som i 200 respons */
@@ -97,7 +97,7 @@ class VeilarbarenaClientImpl(
     override fun hentOppfolgingsbruker(fnr: Fnr): Optional<VeilarbArenaOppfolgingsBruker> {
         val personRequest = PersonRequest(fnr)
         try {
-            val response = httpPost(UrlUtils.joinPaths(veilarbarenaUrl, "/veilarbarena/api/v2/hent-oppfolgingsbruker"), personRequest, VeilarbArenaOppfolgingsBruker::class.java)
+            val response = httpPost(UrlUtils.joinPaths(veilarbarenaUrl, "/veilarbarena/api/v4/hent-oppfolgingsbruker"), personRequest, VeilarbArenaOppfolgingsBruker::class.java)
             return when (response) {
                 is RequestResult.Success -> response.body
                 is RequestResult.Fail -> Optional.empty()
@@ -112,7 +112,7 @@ class VeilarbarenaClientImpl(
     override fun getArenaOppfolgingsstatus(fnr: Fnr): Optional<VeilarbArenaOppfolgingsStatus> {
         val personRequest = PersonRequest(fnr)
         try {
-            val response = httpPost(UrlUtils.joinPaths(veilarbarenaUrl, "/veilarbarena/api/v2/hent-oppfolgingsstatus"), personRequest, VeilarbArenaOppfolgingsStatus::class.java)
+            val response = httpPost(UrlUtils.joinPaths(veilarbarenaUrl, "/veilarbarena/api/v3/hent-oppfolgingsstatus"), personRequest, VeilarbArenaOppfolgingsStatus::class.java)
             return when (response) {
                 is RequestResult.Success -> response.body
                 is RequestResult.Fail -> Optional.empty()

--- a/src/main/kotlin/no/nav/veilarboppfolging/oppfolgingsbruker/arena/ArenaOppfolgingService.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/oppfolgingsbruker/arena/ArenaOppfolgingService.kt
@@ -90,7 +90,7 @@ class ArenaOppfolgingService @Autowired constructor (
 
     private fun hentEnhetSynkrontFraVeilarbarena(fnr: Fnr): EnhetId? {
         return veilarbarenaClient.hentOppfolgingsbruker(fnr)
-            .map { it.nav_kontor }
+            .map { it.navKontor }
             .map { EnhetId(it) }.orElse(null)
     }
 
@@ -125,7 +125,7 @@ class ArenaOppfolgingService @Autowired constructor (
                         return@let it.get()
                     }
                 OppfolgingsData(
-                    veilarbArenaOppfolging.nav_kontor?.let { EnhetId.of(it) },
+                    veilarbArenaOppfolging.navKontor?.let { EnhetId.of(it) },
                     Kvalifiseringsgruppe.valueOf(veilarbArenaOppfolging.kvalifiseringsgruppekode),
                     Formidlingsgruppe.valueOf(veilarbArenaOppfolging.formidlingsgruppekode),
                     veilarbArenaOppfolging.hovedmaalkode?.let { Hovedmaal.valueOf(it) }

--- a/src/test/java/no/nav/veilarboppfolging/client/VeilarbarenaClientImplTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/client/VeilarbarenaClientImplTest.java
@@ -134,7 +134,7 @@ public class VeilarbarenaClientImplTest {
         assertThat(arenaOppfolgingsbruker.getFodselsnr()).isEqualTo("1234");
         assertThat(arenaOppfolgingsbruker.getFormidlingsgruppekode()).isEqualTo(MOCK_FORMIDLINGSGRUPPE);
         assertThat(arenaOppfolgingsbruker.getRettighetsgruppekode()).isEqualTo(MOCK_RETTIGHETSGRUPPE);
-        assertThat(arenaOppfolgingsbruker.getNav_kontor()).isEqualTo(MOCK_ENHET_ID);
+        assertThat(arenaOppfolgingsbruker.getNavKontor()).isEqualTo(MOCK_ENHET_ID);
         assertThat(arenaOppfolgingsbruker.getHovedmaalkode()).isEqualTo(MOCK_HOVEDMAAL);
     }
 
@@ -225,7 +225,7 @@ public class VeilarbarenaClientImplTest {
                 .setFormidlingsgruppekode(MOCK_FORMIDLINGSGRUPPE)
                 .setKvalifiseringsgruppekode(MOCK_KVALIFISERINGSGRUPPE)
                 .setRettighetsgruppekode(MOCK_RETTIGHETSGRUPPE)
-                .setNav_kontor(MOCK_ENHET_ID)
+                .setNavKontor(MOCK_ENHET_ID)
                 .setHovedmaalkode(MOCK_HOVEDMAAL);
     }
 }

--- a/src/test/java/no/nav/veilarboppfolging/client/VeilarbarenaClientImplTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/client/VeilarbarenaClientImplTest.java
@@ -49,7 +49,7 @@ public class VeilarbarenaClientImplTest {
         String apiScope = "api://local.pto.veilarbarena/.default";
         VeilarbarenaClientImpl veilarbarenaClient = new VeilarbarenaClientImpl(apiUrl, apiScope, authServiceMock);
 
-        givenThat(post(urlEqualTo("/veilarbarena/api/v2/hent-oppfolgingsstatus")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
+        givenThat(post(urlEqualTo("/veilarbarena/api/v3/hent-oppfolgingsstatus")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader(CONTENT_TYPE, MEDIA_TYPE_JSON.toString())
@@ -70,7 +70,7 @@ public class VeilarbarenaClientImplTest {
         String apiUrl = "http://localhost:" + wireMockRule.port();
         VeilarbarenaClientImpl veilarbarenaClient = new VeilarbarenaClientImpl(apiUrl, apiScope,authServiceMock);
 
-        givenThat(post(urlEqualTo("/veilarbarena/api/v2/hent-oppfolgingsstatus")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
+        givenThat(post(urlEqualTo("/veilarbarena/api/v3/hent-oppfolgingsstatus")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
                 .willReturn(aResponse().withStatus(404)));
 
         assertTrue(veilarbarenaClient.getArenaOppfolgingsstatus(MOCK_FNR).isEmpty());
@@ -81,7 +81,7 @@ public class VeilarbarenaClientImplTest {
         String apiUrl = "http://localhost:" + wireMockRule.port();
         VeilarbarenaClientImpl veilarbarenaClient = new VeilarbarenaClientImpl(apiUrl, apiScope, authServiceMock);
 
-        givenThat(post(urlEqualTo("/veilarbarena/api/v2/hent-oppfolgingsstatus")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
+        givenThat(post(urlEqualTo("/veilarbarena/api/v3/hent-oppfolgingsstatus")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
                 .willReturn(aResponse().withStatus(403)));
 
         assertTrue(veilarbarenaClient.getArenaOppfolgingsstatus(MOCK_FNR).isEmpty());
@@ -103,7 +103,7 @@ public class VeilarbarenaClientImplTest {
         String apiUrl = "http://localhost:" + wireMockRule.port();
         VeilarbarenaClientImpl veilarbarenaClient = new VeilarbarenaClientImpl(apiUrl, apiScope, authServiceMock);
 
-        givenThat(post(urlEqualTo("/veilarbarena/api/v2/hent-oppfolgingsstatus")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
+        givenThat(post(urlEqualTo("/veilarbarena/api/v3/hent-oppfolgingsstatus")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
                 .willReturn(aResponse().withStatus(400)));
 
         assertTrue(veilarbarenaClient.getArenaOppfolgingsstatus(MOCK_FNR).isEmpty());
@@ -122,7 +122,7 @@ public class VeilarbarenaClientImplTest {
         String apiUrl = "http://localhost:" + wireMockRule.port();
         VeilarbarenaClientImpl veilarbarenaClient = new VeilarbarenaClientImpl(apiUrl, apiScope, authServiceMock);
 
-        givenThat(post(urlEqualTo("/veilarbarena/api/v2/hent-oppfolgingsbruker")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
+        givenThat(post(urlEqualTo("/veilarbarena/api/v4/hent-oppfolgingsbruker")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader(CONTENT_TYPE, MEDIA_TYPE_JSON.toString())
@@ -143,8 +143,8 @@ public class VeilarbarenaClientImplTest {
         String apiUrl = "http://localhost:" + wireMockRule.port();
         VeilarbarenaClientImpl veilarbarenaClient = new VeilarbarenaClientImpl(apiUrl, apiScope,authServiceMock);
 
-        givenThat(post(urlEqualTo("/veilarbarena/api/v2/hent-oppfolgingsbruker")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
-                .willReturn(aResponse().withStatus(404)));
+        givenThat(post(urlEqualTo("/veilarbarena/api/v4/hent-oppfolgingsbruker")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
+                .willReturn(aResponse().withStatus(204)));
 
         assertTrue(veilarbarenaClient.hentOppfolgingsbruker(MOCK_FNR).isEmpty());
     }
@@ -154,7 +154,7 @@ public class VeilarbarenaClientImplTest {
         String apiUrl = "http://localhost:" + wireMockRule.port();
         VeilarbarenaClientImpl veilarbarenaClient = new VeilarbarenaClientImpl(apiUrl, apiScope, authServiceMock);
 
-        givenThat(post(urlEqualTo("/veilarbarena/api/v2/hent-oppfolgingsbruker")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
+        givenThat(post(urlEqualTo("/veilarbarena/api/v4/hent-oppfolgingsbruker")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
                 .willReturn(aResponse().withStatus(403)));
 
         assertTrue(veilarbarenaClient.hentOppfolgingsbruker(MOCK_FNR).isEmpty());
@@ -165,7 +165,7 @@ public class VeilarbarenaClientImplTest {
         String apiUrl = "http://localhost:" + wireMockRule.port();
         VeilarbarenaClientImpl veilarbarenaClient = new VeilarbarenaClientImpl(apiUrl, apiScope, authServiceMock);
 
-        givenThat(post(urlEqualTo("/veilarbarena/api/v2/hent-oppfolgingsbruker")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
+        givenThat(post(urlEqualTo("/veilarbarena/api/v4/hent-oppfolgingsbruker")).withRequestBody(equalToJson("{\"fnr\":\""+MOCK_FNR+"\"}"))
                 .willReturn(aResponse().withStatus(400)));
 
         assertTrue(veilarbarenaClient.hentOppfolgingsbruker(MOCK_FNR).isEmpty());

--- a/src/test/kotlin/no/nav/veilarboppfolging/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/IntegrationTest.kt
@@ -413,9 +413,9 @@ open class IntegrationTest {
                     .setFodselsnr(fnr.get())
                     .setFormidlingsgruppekode(formidlingsgruppe?.name)
                     .setHovedmaalkode("BEHOLDEA")
-                    .setIserv_fra_dato(iservFraDato)
+                    .setIservFraDato(iservFraDato)
                     .setKvalifiseringsgruppekode(kvalifiseringsgruppe.name)
-                    .setNav_kontor(oppfolgingsEnhet)
+                    .setNavKontor(oppfolgingsEnhet)
             )
         )
     }

--- a/src/test/kotlin/no/nav/veilarboppfolging/kafka/EndringPaOppfolgingBrukerConsumerTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/kafka/EndringPaOppfolgingBrukerConsumerTest.kt
@@ -209,7 +209,7 @@ class EndringPaOppfolgingBrukerConsumerTest: IntegrationTest() {
     fun `skal bruke veilarbarena som fallback til oppfølgingsenhet`() {
         val arenaEnhet = "6112"
         val arenaOppfolging = VeilarbArenaOppfolgingsBruker()
-            .setNav_kontor(arenaEnhet)
+            .setNavKontor(arenaEnhet)
         `when`(veilarbarenaClient.hentOppfolgingsbruker(fnr)).thenReturn(Optional.of(arenaOppfolging))
         val enhet = arenaOppfolgingService.hentArenaOppfolgingsEnhetId(fnr)
         assertEquals(arenaEnhet, enhet?.get())

--- a/src/test/kotlin/no/nav/veilarboppfolging/oppfolgingsbruker/arena/VeilarbArenaOppfolgingsStatusServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/oppfolgingsbruker/arena/VeilarbArenaOppfolgingsStatusServiceIntegrationTest.kt
@@ -31,7 +31,7 @@ class VeilarbArenaOppfolgingsStatusServiceIntegrationTest: IntegrationTest() {
         `when`(veilarbarenaClient.hentOppfolgingsbruker(fnr)).thenReturn(Optional.of(
             VeilarbArenaOppfolgingsBruker()
             .setFodselsnr(fnr.get())
-            .setNav_kontor("1010")
+            .setNavKontor("1010")
             .setFormidlingsgruppekode("ARBS")
             .setKvalifiseringsgruppekode("VURDU")
             .setHovedmaalkode("SKAFFEA")

--- a/src/test/kotlin/no/nav/veilarboppfolging/service/KvpServiceTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/service/KvpServiceTest.kt
@@ -67,7 +67,7 @@ class KvpServiceTest{
         )
 
         val veilarbArenaOppfolgingsBruker = VeilarbArenaOppfolgingsBruker()
-        veilarbArenaOppfolgingsBruker.setNav_kontor(ENHET)
+        veilarbArenaOppfolgingsBruker.setNavKontor(ENHET)
         `when`<EnhetId?>(arenaOppfolgingService.hentArenaOppfolgingsEnhetId(FNR))
             .thenReturn(EnhetId.of(ENHET))
 


### PR DESCRIPTION
- Bruk endepukter som gir 204 istedetfor 404 som gir warning i loggene når bruker ikke fines i Arena
- Bytt til nyeste versjon av oppfolgingsbruker (v3 modell, v4 på endepunktet) som endret skrivemåten på noen felter vi brukte