### PR TITLE
sjekker om man har skrivetilgang i stedet for å hardkode det til true

### DIFF
--- a/src/main/java/no/nav/veilarboppfolging/controller/OppfolgingController.java
+++ b/src/main/java/no/nav/veilarboppfolging/controller/OppfolgingController.java
@@ -39,7 +39,7 @@ public class OppfolgingController {
     @GetMapping
     public OppfolgingStatus hentOppfolgingsStatus(@RequestParam(value = "fnr", required = false) Fnr fnr) {
         Fnr fodselsnummer = authService.hentIdentForEksternEllerIntern(fnr);
-        return tilDto(oppfolgingService.hentOppfolgingsStatus(fodselsnummer), authService.erInternBruker());
+        return tilDto(oppfolgingService.hentOppfolgingsStatus(fodselsnummer), authService.erInternBruker(), authService.harSkriveTilgangTilFnr(fodselsnummer));
     }
 
     @GetMapping("/avslutningStatus")
@@ -58,7 +58,7 @@ public class OppfolgingController {
                 KodeverkBruker.NAV, authService.getInnloggetVeilederIdent()
         );
 
-        return tilDto(oppfolgingService.hentOppfolgingsStatus(fnr), authService.erInternBruker());
+        return tilDto(oppfolgingService.hentOppfolgingsStatus(fnr), authService.erInternBruker(), authService.harSkriveTilgangTilFnr(fnr));
     }
 
     // TODO: Ikke returner OppfolgingStatus
@@ -70,7 +70,7 @@ public class OppfolgingController {
 
         if (authService.erEksternBruker()) {
             manuellStatusService.settDigitalBruker(fodselsnummer);
-            return tilDto(oppfolgingService.hentOppfolgingsStatus(fodselsnummer), authService.erInternBruker());
+            return tilDto(oppfolgingService.hentOppfolgingsStatus(fodselsnummer), authService.erInternBruker(), authService.harSkriveTilgangTilFnr(fnr));
         }
 
         // Påkrevd for intern bruker
@@ -83,7 +83,7 @@ public class OppfolgingController {
                 KodeverkBruker.NAV, hentBrukerInfo().getId()
         );
 
-        return tilDto(oppfolgingService.hentOppfolgingsStatus(fodselsnummer), authService.erInternBruker());
+        return tilDto(oppfolgingService.hentOppfolgingsStatus(fodselsnummer), authService.erInternBruker(), authService.harSkriveTilgangTilFnr(fodselsnummer));
     }
 
     @PostMapping("/startKvp")

--- a/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
+++ b/src/main/java/no/nav/veilarboppfolging/service/AuthService.java
@@ -221,6 +221,19 @@ public class AuthService {
         }
     }
 
+    public boolean harSkriveTilgangTilFnr(Fnr fnr) {
+        if (erEksternBruker()) {
+            return harEksternBrukerTilgang(fnr);
+        } else {
+            try {
+                sjekkTilgang(TilgangType.SKRIVE, fnr);
+            } catch (Exception e) {
+                return false;
+            }
+            return true;
+        }
+    }
+
     public void sjekkSkrivetilgangMedAktorId(AktorId aktorId) {
         sjekkTilgang(TilgangType.SKRIVE, aktorId);
     }

--- a/src/main/java/no/nav/veilarboppfolging/utils/DtoMappers.java
+++ b/src/main/java/no/nav/veilarboppfolging/utils/DtoMappers.java
@@ -58,7 +58,7 @@ public class DtoMappers {
         );
     }
 
-    public static OppfolgingStatus tilDto(OppfolgingStatusData oppfolgingStatusData, boolean erInternBruker) {
+    public static OppfolgingStatus tilDto(OppfolgingStatusData oppfolgingStatusData, boolean erInternBruker, boolean harSkriveTilgang) {
         OppfolgingStatus status = new OppfolgingStatus()
                 .setFnr(oppfolgingStatusData.fnr)
                 .setAktorId(oppfolgingStatusData.aktorId)
@@ -72,7 +72,7 @@ public class DtoMappers {
                 .setInaktiveringsdato(oppfolgingStatusData.inaktiveringsdato)
                 .setErIkkeArbeidssokerUtenOppfolging(oppfolgingStatusData.getErSykmeldtMedArbeidsgiver())
                 .setErSykmeldtMedArbeidsgiver(oppfolgingStatusData.getErSykmeldtMedArbeidsgiver())
-                .setHarSkriveTilgang(true)
+                .setHarSkriveTilgang(harSkriveTilgang)
                 .setServicegruppe(oppfolgingStatusData.getServicegruppe())
                 .setFormidlingsgruppe(oppfolgingStatusData.getFormidlingsgruppe())
                 .setRettighetsgruppe(oppfolgingStatusData.getRettighetsgruppe())

--- a/src/main/kotlin/no/nav/veilarboppfolging/controller/OppfolgingV3Controller.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/controller/OppfolgingV3Controller.kt
@@ -88,7 +88,8 @@ class OppfolgingV3Controller(
         val fodselsnummer = authService.hentIdentForEksternEllerIntern(maybeFodselsnummer)
         return DtoMappers.tilDto(
             oppfolgingService.hentOppfolgingsStatus(fodselsnummer),
-            authService.erInternBruker()
+            authService.erInternBruker(),
+            authService.harSkriveTilgangTilFnr(fodselsnummer)
         )
     }
 


### PR DESCRIPTION
Sjekker om man faktisk har skrivetilgang og bruker den verdien i stedet for å hardkode det til true. Hardkodingen gjør at man får tilgang til funksjonalitet i visning som feiler når man forsøker å bruke dem (f.eks. at man kan starte dialoger). 

https://trello.com/c/TFMzLa8B/1608-s12-flere-muterende-endepunkter-sjekker-kun-for-tilgangstypelese-veilarbdialog