### PR TITLE
Lag endepunkt for å hente ut tags for kandidatForUtmelding

### DIFF
--- a/src/main/kotlin/no/nav/veilarboppfolging/controller/graphql/GraphqlController.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/controller/graphql/GraphqlController.kt
@@ -79,11 +79,22 @@ class GraphqlController(
 
     @QueryMapping
     fun utmeldingskandidatTag(@Argument fnr: String? = null): DataFetcherResult<KandidatForUtmeldingTag> {
-        val dataFetchResult = DataFetcherResult.newResult<OppfolgingsEnhetQueryDto>()
         val tilgang = sjekkTilgang(fnr, EksterneHarIkkeTilgang)
         if (tilgang is HarIkkeTilgang) throw ForbiddenException("Ikke tilgang til utmeldingskandidatTag: ${tilgang.message}")
 
+        val eksternBrukerId = fnrFraContext(fnr)
 
+        val dataFetchResult = DataFetcherResult.newResult<KandidatForUtmeldingTag>()
+        val fnr = eksternBrukerId.getFnr()
+        val aktorId = eksternBrukerId.getAktorId()
+
+        val localContext = GraphQLContext.getDefault()
+            .put("fnr", fnr)
+            .put("aktorId", aktorId)
+
+        return kandidatForUtmeldingService.hentKandidatForUtmeldingTag(aktorId).let { tag ->
+            dataFetchResult.localContext(localContext).data(tag).build()
+        }
     }
 
     @QueryMapping

--- a/src/main/kotlin/no/nav/veilarboppfolging/controller/graphql/GraphqlController.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/controller/graphql/GraphqlController.kt
@@ -2,8 +2,6 @@ package no.nav.veilarboppfolging.controller.graphql
 
 import graphql.GraphQLContext
 import graphql.execution.DataFetcherResult
-import java.time.format.DateTimeFormatter
-import kotlin.jvm.optionals.getOrNull
 import no.nav.common.auth.context.UserRole
 import no.nav.common.client.aktoroppslag.AktorOppslagClient
 import no.nav.common.client.norg2.Norg2Client
@@ -18,19 +16,12 @@ import no.nav.pto_schema.enums.arena.Formidlingsgruppe
 import no.nav.veilarboppfolging.ForbiddenException
 import no.nav.veilarboppfolging.client.pdl.PdlFolkeregisterStatusClient
 import no.nav.veilarboppfolging.controller.PoaoTilgangError
-import no.nav.veilarboppfolging.controller.graphql.brukerStatus.BrukerStatusArenaDto
-import no.nav.veilarboppfolging.controller.graphql.brukerStatus.BrukerStatusDto
-import no.nav.veilarboppfolging.controller.graphql.brukerStatus.BrukerStatusKrrDto
-import no.nav.veilarboppfolging.controller.graphql.brukerStatus.BrukerStatusManuellDto
-import no.nav.veilarboppfolging.controller.graphql.brukerStatus.KontorSperre
-import no.nav.veilarboppfolging.controller.graphql.brukerStatus.VeilederTilordningDto
-import no.nav.veilarboppfolging.controller.graphql.oppfolging.EnhetDto
-import no.nav.veilarboppfolging.controller.graphql.oppfolging.KildeDto
-import no.nav.veilarboppfolging.controller.graphql.oppfolging.OppfolgingDto
-import no.nav.veilarboppfolging.controller.graphql.oppfolging.OppfolgingsEnhetQueryDto
-import no.nav.veilarboppfolging.controller.graphql.oppfolging.OppfolgingsperiodeDto
+import no.nav.veilarboppfolging.controller.graphql.brukerStatus.*
+import no.nav.veilarboppfolging.controller.graphql.oppfolging.*
 import no.nav.veilarboppfolging.controller.graphql.veilederTilgang.VeilederTilgangDto
 import no.nav.veilarboppfolging.ident.toCommonIdent
+import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingService
+import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingTag
 import no.nav.veilarboppfolging.oppfolgingsbruker.arena.ArenaOppfolgingService
 import no.nav.veilarboppfolging.oppfolgingsbruker.inngang.ErBrukerUnderOppfolging
 import no.nav.veilarboppfolging.oppfolgingsbruker.inngang.KanStarteOppfolgingDto
@@ -38,11 +29,7 @@ import no.nav.veilarboppfolging.oppfolgingsbruker.inngang.KanStarteOppfolgingEks
 import no.nav.veilarboppfolging.oppfolgingsbruker.inngang.KanStarteOppfolgingEksterneDto.Companion.sjekkKanStarteOppfolgingPaBrukerForEksterne
 import no.nav.veilarboppfolging.oppfolgingsbruker.inngang.KanStarteOppfolgingSjekk.Companion.sjekkKanStarteOppfolgingPaBrukerForVeileder
 import no.nav.veilarboppfolging.oppfolgingsbruker.inngang.toKanStarteOppfolging
-import no.nav.veilarboppfolging.repository.ArbeidsoppfolgingskontorRepository
-import no.nav.veilarboppfolging.repository.KvpRepository
-import no.nav.veilarboppfolging.repository.OppfolgingsPeriodeRepository
-import no.nav.veilarboppfolging.repository.OppfolgingsStatusRepository
-import no.nav.veilarboppfolging.repository.VeilederTilordningerRepository
+import no.nav.veilarboppfolging.repository.*
 import no.nav.veilarboppfolging.repository.entity.OppfolgingsperiodeEntity
 import no.nav.veilarboppfolging.service.AuthService
 import no.nav.veilarboppfolging.service.ManuellStatusService
@@ -55,6 +42,8 @@ import org.springframework.graphql.data.method.annotation.SchemaMapping
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Controller
 import org.springframework.web.server.ResponseStatusException
+import java.time.format.DateTimeFormatter
+import kotlin.jvm.optionals.getOrNull
 
 enum class TilgangResultat {
     HAR_TILGANG,
@@ -79,7 +68,8 @@ class GraphqlController(
     private val oppfolgingService: OppfolgingService,
     private val kvpRepository: KvpRepository,
     private val veilederTilordningerRepository: VeilederTilordningerRepository,
-    private val arbeidsoppfolgingskontorRepository: ArbeidsoppfolgingskontorRepository
+    private val arbeidsoppfolgingskontorRepository: ArbeidsoppfolgingskontorRepository,
+    private val kandidatForUtmeldingService: KandidatForUtmeldingService,
 ) {
     private val logger = LoggerFactory.getLogger(GraphqlController::class.java)
 
@@ -88,7 +78,13 @@ class GraphqlController(
     }
 
     @QueryMapping
-    fun utmeldingskandidatTag(@Argument fnr: String? = null): DataFetcherResult<>
+    fun utmeldingskandidatTag(@Argument fnr: String? = null): DataFetcherResult<KandidatForUtmeldingTag> {
+        val dataFetchResult = DataFetcherResult.newResult<OppfolgingsEnhetQueryDto>()
+        val tilgang = sjekkTilgang(fnr, EksterneHarIkkeTilgang)
+        if (tilgang is HarIkkeTilgang) throw ForbiddenException("Ikke tilgang til utmeldingskandidatTag: ${tilgang.message}")
+
+
+    }
 
     @QueryMapping
     fun oppfolgingsEnhet(@Argument fnr: String? = null): DataFetcherResult<OppfolgingsEnhetQueryDto> {

--- a/src/main/kotlin/no/nav/veilarboppfolging/controller/graphql/GraphqlController.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/controller/graphql/GraphqlController.kt
@@ -88,6 +88,9 @@ class GraphqlController(
     }
 
     @QueryMapping
+    fun utmeldingskandidatTag(@Argument fnr: String? = null): DataFetcherResult<>
+
+    @QueryMapping
     fun oppfolgingsEnhet(@Argument fnr: String? = null): DataFetcherResult<OppfolgingsEnhetQueryDto> {
         val dataFetchResult = DataFetcherResult.newResult<OppfolgingsEnhetQueryDto>()
         val tilgang = sjekkTilgang(fnr, AlleHarTilgang(AuthService.SikkerthetsNivå.Nivå3))

--- a/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingHendelse.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingHendelse.kt
@@ -2,8 +2,10 @@ package no.nav.veilarboppfolging.kandidatForUtmelding
 
 import no.nav.common.types.identer.AktorId
 import no.nav.common.types.identer.Fnr
-import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.AvregistreringsType
-import java.time.ZonedDateTime
+import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingTag.ARBEIDSSOKERPERIODE_AVSLUTTET_BRUKER
+import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingTag.ARBEIDSSOKERPERIODE_AVSLUTTET_SYSTEM
+import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingTag.ARBEIDSSOKERPERIODE_AVSLUTTET_UKJENT
+import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingTag.ARBEIDSSOKERPERIODE_AVSLUTTET_VEILEDER
 import java.util.UUID
 
 sealed class KandidatForUtmeldingHendelse(
@@ -15,6 +17,19 @@ sealed class KandidatForUtmeldingHendelse(
     val aarsak: String?,
 ) {
     abstract val type: KandidatForUtmeldingHendelseType
+
+    fun mapTilTag(): KandidatForUtmeldingTag {
+        return when (type) {
+            KandidatForUtmeldingHendelseType.ARBEIDSSOKERPERIODE_AVSLUTTET -> {
+                when (avsluttetAv) {
+                    KandidatForUtmeldingHendelseAvsluttetAv.BRUKER -> ARBEIDSSOKERPERIODE_AVSLUTTET_BRUKER
+                    KandidatForUtmeldingHendelseAvsluttetAv.VEILEDER -> ARBEIDSSOKERPERIODE_AVSLUTTET_VEILEDER
+                    KandidatForUtmeldingHendelseAvsluttetAv.SYSTEM -> ARBEIDSSOKERPERIODE_AVSLUTTET_SYSTEM
+                    KandidatForUtmeldingHendelseAvsluttetAv.UKJENT -> ARBEIDSSOKERPERIODE_AVSLUTTET_UKJENT
+                }
+            }
+        }
+    }
 }
 
 enum class KandidatForUtmeldingHendelseType {

--- a/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingRepository.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingRepository.kt
@@ -42,7 +42,10 @@ class KandidatForUtmeldingRepository(
     fun hentKandidat(aktorId: AktorId): KandidatForUtmeldingHendelse? {
         return db.query(
             """
-            SELECT * FROM kandidat_for_utmelding WHERE aktor_id = :aktor_id
+            SELECT kandidat_for_utmelding.* FROM kandidat_for_utmelding 
+            INNER JOIN oppfolgingsperiode ON oppfolgingsperiode.uuid = kandidat_for_utmelding.oppfolgingsperiode_uuid
+            WHERE aktor_id = :aktor_id
+            AND oppfolgingsperiode.sluttdato is null
             """.trimIndent(),
             mapOf("aktor_id" to aktorId.get()),
         ) { rs, _ -> map(rs) }

--- a/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingRepository.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingRepository.kt
@@ -44,7 +44,7 @@ class KandidatForUtmeldingRepository(
             """
             SELECT kandidat_for_utmelding.* FROM kandidat_for_utmelding 
             INNER JOIN oppfolgingsperiode ON oppfolgingsperiode.uuid = kandidat_for_utmelding.oppfolgingsperiode_uuid
-            WHERE aktor_id = :aktor_id
+            WHERE kandidat_for_utmelding.aktor_id = :aktor_id
             AND oppfolgingsperiode.sluttdato is null
             """.trimIndent(),
             mapOf("aktor_id" to aktorId.get()),

--- a/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingService.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingService.kt
@@ -1,7 +1,6 @@
 package no.nav.veilarboppfolging.kandidatForUtmelding
 
 import no.nav.common.types.identer.AktorId
-import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.AvregistreringsType
 import no.nav.veilarboppfolging.service.AvsluttOppfolgingService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -35,5 +34,9 @@ class KandidatForUtmeldingService(
     fun fjernKandidatForUtmelding(aktorId: AktorId) {
         kandidatForUtmeldingRepository.fjernKandidat(aktorId)
         logger.info("Fjerner kandidat for utmelding")
+    }
+
+    fun hentKandidatForUtmeldingTag(aktorId: AktorId): KandidatForUtmeldingTag? {
+        return kandidatForUtmeldingRepository.hentKandidat(aktorId)?.mapTilTag()
     }
 }

--- a/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingTag.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingTag.kt
@@ -4,8 +4,6 @@ enum class KandidatForUtmeldingTag {
     ARBEIDSSOKERPERIODE_AVSLUTTET_BRUKER,
     ARBEIDSSOKERPERIODE_AVSLUTTET_VEILEDER,
     ARBEIDSSOKERPERIODE_AVSLUTTET_SYSTEM,
-    ARBEIDSSOKERPERIODE_AVSLUTTET_UKJENT;
-
-    fun mapTag(type: KandidatForUtmeldingHendelseType, avsluttetAv: KandidatForUtmeldingHendelseAvsluttetAv ) = when (this) {}
+    ARBEIDSSOKERPERIODE_AVSLUTTET_UKJENT,
 }
 

--- a/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingTag.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingTag.kt
@@ -1,0 +1,11 @@
+package no.nav.veilarboppfolging.kandidatForUtmelding
+
+enum class KandidatForUtmeldingTag {
+    ARBEIDSSOKERPERIODE_AVSLUTTET_BRUKER,
+    ARBEIDSSOKERPERIODE_AVSLUTTET_VEILEDER,
+    ARBEIDSSOKERPERIODE_AVSLUTTET_SYSTEM,
+    ARBEIDSSOKERPERIODE_AVSLUTTET_UKJENT;
+
+    fun mapTag(type: KandidatForUtmeldingHendelseType, avsluttetAv: KandidatForUtmeldingHendelseAvsluttetAv ) = when (this) {}
+}
+

--- a/src/main/resources/graphql/schema.veilarboppfolging.graphqls
+++ b/src/main/resources/graphql/schema.veilarboppfolging.graphqls
@@ -16,6 +16,12 @@ type VeilederTilgang {
     harAktiveTiltaksdeltakelserVedFlyttingTilEgetKontor: Boolean
 }
 
+type Utmeldingskandidat {
+    type: String!,
+    avsluttetAv: String!,
+    aarsak: String!
+}
+
 # Svaret på Evaluerering av Policy-en som heter NavAnsattTilgangTilEksternBruker i POAO-Tilgang
 # Kan kjøres på både lese og skrive tilgang (modia-oppfolging vs modia generell) men er foreløpig bare brukt til lesetilgang
 enum TilgangResultat {

--- a/src/main/resources/graphql/schema.veilarboppfolging.graphqls
+++ b/src/main/resources/graphql/schema.veilarboppfolging.graphqls
@@ -5,6 +5,7 @@ type Query {
     oppfolgingsPerioder(fnr: String!): [Oppfolgingsperiode]
     veilederTilgang(fnr: String!): VeilederTilgang
     gjeldendeOppfolgingsperiode: Oppfolgingsperiode
+    utmeldingskandidatTag(fnr: String!): UtmeldingskandidatTag
 }
 
 type VeilederTilgang {
@@ -16,10 +17,11 @@ type VeilederTilgang {
     harAktiveTiltaksdeltakelserVedFlyttingTilEgetKontor: Boolean
 }
 
-type Utmeldingskandidat {
-    type: String!,
-    avsluttetAv: String!,
-    aarsak: String!
+enum UtmeldingskandidatTag {
+    ARBEIDSSOKERPERIODE_AVSLUTTET_BRUKER,
+    ARBEIDSSOKERPERIODE_AVSLUTTET_VEILEDER,
+    ARBEIDSSOKERPERIODE_AVSLUTTET_SYSTEM,
+    ARBEIDSSOKERPERIODE_AVSLUTTET_UKJENT
 }
 
 # Svaret på Evaluerering av Policy-en som heter NavAnsattTilgangTilEksternBruker i POAO-Tilgang

--- a/src/test/kotlin/no/nav/veilarboppfolging/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/IntegrationTest.kt
@@ -50,8 +50,11 @@ import no.nav.veilarboppfolging.config.EnvironmentProperties
 import no.nav.veilarboppfolging.config.KafkaProperties
 import no.nav.veilarboppfolging.controller.OppfolgingController
 import no.nav.veilarboppfolging.controller.SakController
+import no.nav.veilarboppfolging.kandidatForUtmelding.ArbeidssøkerPeriodeAvsluttet
+import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingHendelseAvsluttetAv
 import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingRepository
 import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingService
+import no.nav.veilarboppfolging.oppfolgingsbruker.AvsluttetAvType
 import no.nav.veilarboppfolging.oppfolgingsbruker.BrukerRegistrant
 import no.nav.veilarboppfolging.oppfolgingsbruker.VeilederRegistrant
 import no.nav.veilarboppfolging.oppfolgingsbruker.arena.ArenaOppfolgingService
@@ -253,6 +256,18 @@ open class IntegrationTest {
         val bruker = OppfolgingsRegistrering.arbeidssokerRegistrering(fnr, aktorId, BrukerRegistrant(fnr))
         oppfolgingsStatusRepository.opprettOppfolging(aktorId)
         oppfolgingsPeriodeRepository.start(bruker)
+    }
+
+    fun lagreKandidatForUtmelding(aktorId: AktorId, fnr: Fnr, oppfolgingsperiodeUuid: UUID) {
+        val kandidat = ArbeidssøkerPeriodeAvsluttet(
+            aktorId = aktorId,
+            fnr = fnr,
+            oppfolgingsperiodeUuid = oppfolgingsperiodeUuid,
+            avsluttetAv = KandidatForUtmeldingHendelseAvsluttetAv.VEILEDER,
+            kilde = "arbeidssøkerregisteret",
+            aarsak = "Avsluttet av veileder"
+        )
+        kandidatForUtmeldingService.lagreKandidatForUtmelding(kandidat)
     }
 
     fun setTilordnetVeileder(aktorId: AktorId, veilederIdent: NavIdent) {

--- a/src/test/kotlin/no/nav/veilarboppfolging/controller/GraphqlControllerTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/controller/GraphqlControllerTest.kt
@@ -689,4 +689,22 @@ class GraphqlControllerTest: IntegrationTest() {
             { "kanStarteOppfolgingEkstern": "ALLEREDE_UNDER_OPPFOLGING" }
         """.trimIndent())
     }
+
+    @Test
+    fun `skal returnere kandidatForUtmeldingTag`() {
+        val (fnr, aktorId) = defaultBruker()
+        val veilederUuid = UUID.randomUUID()
+        mockInternBrukerAuthOk(veilederUuid, aktorId, fnr)
+        mockPoaoTilgangHarTilgangTilBruker(veilederUuid, fnr, Decision.Permit)
+        val oppfolgingsperiode = hentOppfolgingsperioder(fnr).first { it.sluttDato == null }
+        setBrukerUnderOppfolging(aktorId, fnr)
+        lagreKandidatForUtmelding(aktorId, fnr, oppfolgingsperiode.uuid)
+
+        /* Query is hidden in test/resources/graphl-test :) */
+        val result = tester.documentName("getUnderOppfolging").variable("fnr", fnr.get()).execute()
+        result.errors().verify()
+        result.path("oppfolging").matchesJson("""
+            { "erUnderOppfolging": true }
+        """.trimIndent())
+    }
 }

--- a/src/test/kotlin/no/nav/veilarboppfolging/controller/GraphqlControllerTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/controller/GraphqlControllerTest.kt
@@ -696,15 +696,31 @@ class GraphqlControllerTest: IntegrationTest() {
         val veilederUuid = UUID.randomUUID()
         mockInternBrukerAuthOk(veilederUuid, aktorId, fnr)
         mockPoaoTilgangHarTilgangTilBruker(veilederUuid, fnr, Decision.Permit)
-        val oppfolgingsperiode = hentOppfolgingsperioder(fnr).first { it.sluttDato == null }
+        mockVeilarbArenaOppfolgingsBruker(fnr, Formidlingsgruppe.ISERV)
         setBrukerUnderOppfolging(aktorId, fnr)
+        val oppfolgingsperiode = hentOppfolgingsperioder(fnr).first { it.sluttDato == null }
         lagreKandidatForUtmelding(aktorId, fnr, oppfolgingsperiode.uuid)
 
         /* Query is hidden in test/resources/graphl-test :) */
-        val result = tester.documentName("getUnderOppfolging").variable("fnr", fnr.get()).execute()
+        val result = tester.documentName("hentKandidatForUtmeldingTag").variable("fnr", fnr.get()).execute()
         result.errors().verify()
-        result.path("oppfolging").matchesJson("""
-            { "erUnderOppfolging": true }
+        result.path("utmeldingskandidatTag").matchesJson("""
+            "ARBEIDSSOKERPERIODE_AVSLUTTET_VEILEDER"
         """.trimIndent())
+    }
+
+    @Test
+    fun `skal returnere null hvis ikke kandidat for utmelding`() {
+        val (fnr, aktorId) = defaultBruker()
+        val veilederUuid = UUID.randomUUID()
+        mockInternBrukerAuthOk(veilederUuid, aktorId, fnr)
+        mockPoaoTilgangHarTilgangTilBruker(veilederUuid, fnr, Decision.Permit)
+        mockVeilarbArenaOppfolgingsBruker(fnr, Formidlingsgruppe.ISERV)
+        setBrukerUnderOppfolging(aktorId, fnr)
+
+        /* Query is hidden in test/resources/graphl-test :) */
+        val result = tester.documentName("hentKandidatForUtmeldingTag").variable("fnr", fnr.get()).execute()
+        result.errors().verify()
+        result.path("utmeldingskandidatTag").equals(null)
     }
 }

--- a/src/test/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingFlytTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingFlytTest.kt
@@ -132,6 +132,45 @@ class KandidatForUtmeldingFlytTest(
     }
 
     @Test
+    fun `Henter ikke kandidat som har fått avsluttet oppfølgingsperioden`() {
+        mockVeilarbArenaOppfolgingsBruker(Fnr.of(fnr), Formidlingsgruppe.ISERV)
+        startOppfolgingSomArbeidsoker(aktorId, Fnr.of(fnr))
+        val oppfolgingsperiodeUuid = oppfolgingService.hentGjeldendeOppfolgingsperiode(Fnr.of(fnr)).get().uuid
+        kandidatForUtmeldingRepository.lagreKandidat(ArbeidssøkerPeriodeAvsluttet(
+            aktorId = aktorId,
+            fnr = Fnr.of(fnr),
+            oppfolgingsperiodeUuid = oppfolgingsperiodeUuid,
+            avsluttetAv = KandidatForUtmeldingHendelseAvsluttetAv.VEILEDER,
+            kilde ="kilde",
+            aarsak = "aarsak")
+        )
+        avsluttOppfolgingManueltSomVeileder(aktorId)
+
+        val kandidat = kandidatForUtmeldingService.hentKandidatForUtmeldingTag(aktorId)
+
+        assertThat(kandidat).isNull()
+    }
+
+    @Test
+    fun `Henter kandidat som har gjeldende oppfølgingsperiode`() {
+        mockVeilarbArenaOppfolgingsBruker(Fnr.of(fnr), Formidlingsgruppe.ISERV)
+        startOppfolgingSomArbeidsoker(aktorId, Fnr.of(fnr))
+        val oppfolgingsperiodeUuid = oppfolgingService.hentGjeldendeOppfolgingsperiode(Fnr.of(fnr)).get().uuid
+        kandidatForUtmeldingRepository.lagreKandidat(ArbeidssøkerPeriodeAvsluttet(
+            aktorId = aktorId,
+            fnr = Fnr.of(fnr),
+            oppfolgingsperiodeUuid = oppfolgingsperiodeUuid,
+            avsluttetAv = KandidatForUtmeldingHendelseAvsluttetAv.VEILEDER,
+            kilde ="kilde",
+            aarsak = "aarsak")
+        )
+
+        val kandidat = kandidatForUtmeldingService.hentKandidatForUtmeldingTag(aktorId)
+
+        assertThat(kandidat).isNotNull()
+    }
+
+    @Test
     fun `Sletter kandidat-for-utmelding når ny oppfølgingsperiode startes manuelt av veileder`() {
         mockVeilarbArenaOppfolgingsBruker(Fnr.of(fnr), Formidlingsgruppe.ISERV)
         startOppfolgingSomArbeidsoker(aktorId, Fnr.of(fnr))

--- a/src/test/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingHendelseTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingHendelseTest.kt
@@ -1,0 +1,57 @@
+package no.nav.veilarboppfolging.kandidatForUtmelding
+
+import no.nav.common.types.identer.AktorId
+import no.nav.common.types.identer.Fnr
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class KandidatForUtmeldingHendelseTest {
+
+    private val aktorId = AktorId.of("1234567890")
+    private val fnr = Fnr.of("12345678901")
+
+    private fun arbeidssøkerPeriodeAvsluttet(
+        avsluttetAv: KandidatForUtmeldingHendelseAvsluttetAv
+    ): ArbeidssøkerPeriodeAvsluttet =
+        ArbeidssøkerPeriodeAvsluttet(
+            aktorId = aktorId,
+            fnr = fnr,
+            oppfolgingsperiodeUuid = UUID.randomUUID(),
+            avsluttetAv = avsluttetAv,
+            kilde = "test",
+            aarsak = null
+        )
+
+    @Test
+    fun `mapTilTag mapper ARBEIDSSOKERPERIODE_AVSLUTTET avsluttet av BRUKER til riktig tag`() {
+        val hendelse = arbeidssøkerPeriodeAvsluttet(KandidatForUtmeldingHendelseAvsluttetAv.BRUKER)
+
+        assertThat(hendelse.mapTilTag())
+            .isEqualTo(KandidatForUtmeldingTag.ARBEIDSSOKERPERIODE_AVSLUTTET_BRUKER)
+    }
+
+    @Test
+    fun `mapTilTag mapper ARBEIDSSOKERPERIODE_AVSLUTTET avsluttet av VEILEDER til riktig tag`() {
+        val hendelse = arbeidssøkerPeriodeAvsluttet(KandidatForUtmeldingHendelseAvsluttetAv.VEILEDER)
+
+        assertThat(hendelse.mapTilTag())
+            .isEqualTo(KandidatForUtmeldingTag.ARBEIDSSOKERPERIODE_AVSLUTTET_VEILEDER)
+    }
+
+    @Test
+    fun `mapTilTag mapper ARBEIDSSOKERPERIODE_AVSLUTTET avsluttet av SYSTEM til riktig tag`() {
+        val hendelse = arbeidssøkerPeriodeAvsluttet(KandidatForUtmeldingHendelseAvsluttetAv.SYSTEM)
+
+        assertThat(hendelse.mapTilTag())
+            .isEqualTo(KandidatForUtmeldingTag.ARBEIDSSOKERPERIODE_AVSLUTTET_SYSTEM)
+    }
+
+    @Test
+    fun `mapTilTag mapper ARBEIDSSOKERPERIODE_AVSLUTTET avsluttet av UKJENT til riktig tag`() {
+        val hendelse = arbeidssøkerPeriodeAvsluttet(KandidatForUtmeldingHendelseAvsluttetAv.UKJENT)
+
+        assertThat(hendelse.mapTilTag())
+            .isEqualTo(KandidatForUtmeldingTag.ARBEIDSSOKERPERIODE_AVSLUTTET_UKJENT)
+    }
+}

--- a/src/test/resources/graphql-test/hentKandidatForUtmeldingTag.graphql
+++ b/src/test/resources/graphql-test/hentKandidatForUtmeldingTag.graphql
@@ -1,3 +1,3 @@
-query utmeldingskandidatTag($fnr: String!) {
-    utmeldingskandidatTag
+query testUtmeldingskandidatTag($fnr: String!) {
+    utmeldingskandidatTag(fnr: $fnr)
 }

--- a/src/test/resources/graphql-test/hentKandidatForUtmeldingTag.graphql
+++ b/src/test/resources/graphql-test/hentKandidatForUtmeldingTag.graphql
@@ -1,0 +1,3 @@
+query utmeldingskandidatTag($fnr: String!) {
+    utmeldingskandidatTag
+}


### PR DESCRIPTION
Tilgjengeliggjør om bruker er utmeldingskandidat og hvorfor via graphql-api slik at det kan brukes for å vise tags. 

https://trello.com/c/h85t5YxQ/1653-lage-tags-for-arbeidss%C3%B8kerperiode-avsluttet-av-bruker-eller-system-og-hvorfor-som-vises-i-visittkortkort