### PR TITLE
Fjerne kandidater

### DIFF
--- a/src/main/kotlin/no/nav/veilarboppfolging/service/AvsluttOppfolgingService.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/service/AvsluttOppfolgingService.kt
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.ZonedDateTime
 import java.util.*
+import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingRepository
 import no.nav.veilarboppfolging.repository.ArbeidsoppfolgingskontorRepository
 
 @Service
@@ -47,6 +48,7 @@ class AvsluttOppfolgingService(
     val bigQueryClient: BigQueryClient,
     val transactor: TransactionTemplate,
     val arbeidsoppfolgingskontorRepository: ArbeidsoppfolgingskontorRepository,
+    val kandidatForUtmeldingRepository: KandidatForUtmeldingRepository
 ) {
 
     val log = LoggerFactory.getLogger(this::class.java)
@@ -151,6 +153,7 @@ class AvsluttOppfolgingService(
             val sistePeriode = OppfolgingsperiodeUtils.hentSisteOppfolgingsperiode(perioder)
 
             arbeidsoppfolgingskontorRepository.slettNavKontor(sistePeriode.uuid)
+            kandidatForUtmeldingRepository.fjernKandidat(aktorId)
 
             log.info("Oppfølgingsperiode avsluttet for bruker - publiserer endringer på oppfølgingsperiode-topics.")
             kafkaProducerService.publiserOppfolgingsperiode(DtoMappers.tilOppfolgingsperiodeDTO(sistePeriode))

--- a/src/main/kotlin/no/nav/veilarboppfolging/service/ReaktiveringService.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/service/ReaktiveringService.kt
@@ -4,6 +4,7 @@ import no.nav.common.types.identer.AktorId
 import no.nav.common.types.identer.Fnr
 import no.nav.common.types.identer.NavIdent
 import no.nav.veilarboppfolging.client.veilarbarena.*
+import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingRepository
 import no.nav.veilarboppfolging.oppfolgingsbruker.arena.ArenaOppfolgingService
 import no.nav.veilarboppfolging.repository.OppfolgingsPeriodeRepository
 import no.nav.veilarboppfolging.repository.OppfolgingsStatusRepository
@@ -24,6 +25,7 @@ class ReaktiveringService(
     val arenaOppfolgingService: ArenaOppfolgingService,
     val reaktiveringRepository: ReaktiveringRepository,
     val oppfolgingsPeriodeRepository: OppfolgingsPeriodeRepository,
+    val kandidatForUtmeldingRepository: KandidatForUtmeldingRepository,
     private val transactor: TransactionTemplate,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(ReaktiveringService::class.java)
@@ -60,7 +62,7 @@ class ReaktiveringService(
                     val arenaKode = arenaResponse.arenaResultat.kode
                     when (arenaKode) {
                         in listOf(ArenaRegistreringResultat.FNR_FINNES_IKKE, ArenaRegistreringResultat.KAN_REAKTIVERES_FORENKLET, ArenaRegistreringResultat.UKJENT_FEIL) -> {
-                            logger.error("Feil ved registrering av bruker i Arena", arenaResponse.arenaResultat.resultat)
+                            logger.error("Feil ved registrering av bruker i Arena: {}", arenaResponse.arenaResultat.resultat)
                             return@execute FeilFraArenaError(arenaKode)
                         }
                         else -> {
@@ -72,6 +74,7 @@ class ReaktiveringService(
                                     veilederIdent = navIdent.get(),
                                 )
                             )
+                            kandidatForUtmeldingRepository.fjernKandidat(aktorId)
                             return@execute ReaktiveringSuccess(arenaKode)
                         }
                     }

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
@@ -23,6 +23,7 @@ import no.nav.veilarboppfolging.domain.AvslutningStatusData;
 import no.nav.veilarboppfolging.domain.OppfolgingStatusData;
 import no.nav.veilarboppfolging.eventsLogger.BigQueryClient;
 import no.nav.veilarboppfolging.kafka.dto.OppfolgingsperiodeDTO;
+import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingRepository;
 import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingService;
 import no.nav.veilarboppfolging.oppfolgingsbruker.BrukerRegistrant;
 import no.nav.veilarboppfolging.oppfolgingsbruker.VeilederRegistrant;
@@ -91,6 +92,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
     private BigQueryClient bigQueryClient = mock(BigQueryClient.class);
     private ArbeidsoppfolgingsKontorService arbeidsoppfolgingsKontorService = mock(ArbeidsoppfolgingsKontorService.class);
     private KandidatForUtmeldingService kandidatForUtmeldingService = mock(KandidatForUtmeldingService.class);
+    private KandidatForUtmeldingRepository kandidatForUtmeldingRepository;
 
     @Before
     public void setup() {
@@ -103,6 +105,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
         oppfolgingsStatusRepository = new OppfolgingsStatusRepository(new NamedParameterJdbcTemplate(db));
         oppfolgingsPeriodeRepository = new OppfolgingsPeriodeRepository(db, transactor);
         arbeidsoppfolgingskontorRepository = new ArbeidsoppfolgingskontorRepository(new NamedParameterJdbcTemplate(db));
+        kandidatForUtmeldingRepository = new KandidatForUtmeldingRepository(new NamedParameterJdbcTemplate(db));
 
         avsluttOppfolgingService = new AvsluttOppfolgingService(
                 authService,
@@ -118,7 +121,8 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
                 arenaYtelserService,
                 bigQueryClient,
                 transactor,
-                arbeidsoppfolgingskontorRepository
+                arbeidsoppfolgingskontorRepository,
+                kandidatForUtmeldingRepository
         );
         oppfolgingService = new OppfolgingService(
                 kvpService,

--- a/src/test/kotlin/no/nav/veilarboppfolging/service/AvsluttOppfolgingServiceTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/service/AvsluttOppfolgingServiceTest.kt
@@ -25,6 +25,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.springframework.transaction.support.TransactionTemplate
 import java.util.*
+import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingRepository
 import no.nav.veilarboppfolging.repository.ArbeidsoppfolgingskontorRepository
 
 class AvsluttOppfolgingServiceTest {
@@ -43,6 +44,7 @@ class AvsluttOppfolgingServiceTest {
     private val bigQueryClient: BigQueryClient = Mockito.mock(BigQueryClient::class.java)
     private val transactionTemplate: TransactionTemplate = Mockito.mock(TransactionTemplate::class.java)
     private val arbeidsoppfolgingskontorRepository: ArbeidsoppfolgingskontorRepository = Mockito.mock(ArbeidsoppfolgingskontorRepository::class.java)
+    private val kandidatForUtmeldingRepository: KandidatForUtmeldingRepository = Mockito.mock(KandidatForUtmeldingRepository::class.java)
 
     private fun <T> any(type: Class<T>): T = Mockito.any<T>(type)
 
@@ -56,6 +58,7 @@ class AvsluttOppfolgingServiceTest {
         bigQueryClient = bigQueryClient,
         transactor = transactionTemplate,
         arbeidsoppfolgingskontorRepository = arbeidsoppfolgingskontorRepository,
+        kandidatForUtmeldingRepository = kandidatForUtmeldingRepository,
     )
 
     private fun arenaIservAvregistrering(): ArenaIservKanIkkeReaktiveres {

--- a/src/test/kotlin/no/nav/veilarboppfolging/service/ReaktiveringServiceTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/service/ReaktiveringServiceTest.kt
@@ -28,6 +28,7 @@ import org.springframework.transaction.support.TransactionCallback
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.ZonedDateTime
 import java.util.*
+import no.nav.veilarboppfolging.kandidatForUtmelding.KandidatForUtmeldingRepository
 
 @RunWith(MockitoJUnitRunner::class)
 class ReaktiveringServiceTest {
@@ -36,6 +37,7 @@ class ReaktiveringServiceTest {
     private var oppfolgingsStatusRepository = mock(OppfolgingsStatusRepository::class.java)
     private var arenaOppfolgingService = mock(ArenaOppfolgingService::class.java)
     private var oppfolgingsPeriodeRepository = mock(OppfolgingsPeriodeRepository::class.java)
+    private var kandidatForUtmeldingRepository = mock(KandidatForUtmeldingRepository::class.java)
     private var transactor = mock(TransactionTemplate::class.java)
     private val reaktiveringService = ReaktiveringService(
         authService,
@@ -43,6 +45,7 @@ class ReaktiveringServiceTest {
         arenaOppfolgingService,
         reaktiveringRepository,
         oppfolgingsPeriodeRepository,
+        kandidatForUtmeldingRepository,
         transactor
     )
 


### PR DESCRIPTION
Sletter kandidat for utmelding hvis oppfølgingsperioden avsluttes eller hvis den reaktiveres. Hensikten er å kun beholde aktive kandidater for utmelding i tabellen. 

https://trello.com/c/BmMC2Jmp/1662-endre-logikk-for-utmeldingskandidater-vi-har-lagret