### PR TITLE
fjerner joins fra kandidat-repository og legger til flere tester

### DIFF
--- a/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingRepository.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingRepository.kt
@@ -1,13 +1,11 @@
 package no.nav.veilarboppfolging.kandidatForUtmelding
 
+import java.sql.ResultSet
+import java.util.UUID
 import no.nav.common.types.identer.AktorId
 import no.nav.common.types.identer.Fnr
-import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.AvregistreringsType
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
-import java.sql.ResultSet
-import java.time.ZonedDateTime
-import java.util.*
 
 @Repository
 class KandidatForUtmeldingRepository(
@@ -42,18 +40,8 @@ class KandidatForUtmeldingRepository(
     fun hentKandidat(aktorId: AktorId): KandidatForUtmeldingHendelse? {
         return db.query(
             """
-            SELECT kandidat_for_utmelding.* FROM kandidat_for_utmelding 
-            INNER JOIN oppfolgingsperiode ON oppfolgingsperiode.uuid = kandidat_for_utmelding.oppfolgingsperiode_uuid
-            WHERE kandidat_for_utmelding.aktor_id = :aktor_id
-            AND oppfolgingsperiode.sluttdato is null
-            AND COALESCE(
-                (
-                    SELECT MAX(reaktivering_tidspunkt)
-                    FROM historikk_for_reaktivering
-                    WHERE oppfolgingsperiode = kandidat_for_utmelding.oppfolgingsperiode_uuid
-                ),
-                '-infinity'
-            ) < kandidat_for_utmelding.created_at
+            SELECT * FROM kandidat_for_utmelding 
+            WHERE aktor_id = :aktor_id
             """.trimIndent(),
             mapOf("aktor_id" to aktorId.get()),
         ) { rs, _ -> map(rs) }

--- a/src/test/kotlin/no/nav/veilarboppfolging/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/IntegrationTest.kt
@@ -43,6 +43,9 @@ import no.nav.veilarboppfolging.client.pdl.PdlFolkeregisterStatusClient
 import no.nav.veilarboppfolging.client.tiltakshistorikk.TiltakshistorikkClient
 import no.nav.veilarboppfolging.client.ungdomsprogram.UngdomsprogramClient
 import no.nav.veilarboppfolging.client.veilarbarena.ArenaOppfolginsBrukerOppslagResult
+import no.nav.veilarboppfolging.client.veilarbarena.ArenaRegistreringResultat
+import no.nav.veilarboppfolging.client.veilarbarena.RegistrerIArenaSuccess
+import no.nav.veilarboppfolging.client.veilarbarena.RegistrerIkkeArbeidssokerDto
 import no.nav.veilarboppfolging.client.veilarbarena.VeilarbArenaOppfolgingsBruker
 import no.nav.veilarboppfolging.client.veilarbarena.VeilarbArenaOppfolgingsStatus
 import no.nav.veilarboppfolging.client.veilarbarena.VeilarbarenaClient
@@ -83,6 +86,7 @@ import no.nav.veilarboppfolging.tokenClient.ErrorMappedAzureAdOnBehalfOfTokenCli
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
@@ -477,6 +481,17 @@ open class IntegrationTest {
                     null,
                     null,
                     null,
+                )
+            )
+        )
+    }
+
+    fun mockArenaOppfolgingServiceRegistrerIkkeArbeidssoker(fnr: Fnr) {
+        `when`(arenaOppfolgingService.registrerIkkeArbeidssoker(fnr)).thenReturn(
+            RegistrerIArenaSuccess(
+                RegistrerIkkeArbeidssokerDto(
+                    "Bruker reaktivert i Arena",
+                    ArenaRegistreringResultat.OK_REGISTRERT_I_ARENA
                 )
             )
         )

--- a/src/test/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingFlytTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingFlytTest.kt
@@ -4,7 +4,6 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
-import java.time.ZonedDateTime
 import java.util.UUID
 import no.nav.common.types.identer.AktorId
 import no.nav.common.types.identer.EnhetId
@@ -21,22 +20,18 @@ import no.nav.veilarboppfolging.IntegrationTest
 import no.nav.veilarboppfolging.kafka.ArbeidssøkerperiodeConsumerService
 import no.nav.veilarboppfolging.kafka.TestUtils
 import no.nav.veilarboppfolging.oppfolgingsbruker.VeilederRegistrant
-import no.nav.veilarboppfolging.oppfolgingsbruker.arena.EndringPaaOppfolgingsBruker
 import no.nav.veilarboppfolging.oppfolgingsbruker.inngang.OppfolgingsRegistrering
-import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.AvregistreringsType
-import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.OppdateringFraArena_BleIserv
 import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.UtmeldingsService
 import no.nav.veilarboppfolging.repository.UtmeldingRepository
 import no.nav.veilarboppfolging.service.KafkaConsumerService
 import no.nav.veilarboppfolging.service.OppfolgingsbrukerEndretIArenaService
+import no.nav.veilarboppfolging.service.ReaktiveringService
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.temporal.ChronoUnit
 import no.nav.paw.arbeidssokerregisteret.api.v1.Metadata as MetaData
 
 class KandidatForUtmeldingFlytTest(
@@ -50,6 +45,8 @@ class KandidatForUtmeldingFlytTest(
     val utmeldingsService: UtmeldingsService,
     @Autowired
     val oppfolgingsbrukerEndretIArenaService: OppfolgingsbrukerEndretIArenaService,
+    @Autowired
+    val reaktiveringService: ReaktiveringService,
 ) : IntegrationTest() {
 
     private val fnr = "01010198765"
@@ -194,6 +191,38 @@ class KandidatForUtmeldingFlytTest(
     }
 
     @Test
+    fun `Sletter kandidat-for-utmelding hvis bruker er under oppfølging og starter ny arbeidssøkerperiode`() {
+        mockVeilarbArenaOppfolgingsBruker(Fnr.of(fnr), Formidlingsgruppe.ISERV)
+        startOppfolgingSomArbeidsoker(aktorId, Fnr.of(fnr))
+        val oppfolgingsperiodeUuid = oppfolgingService.hentGjeldendeOppfolgingsperiode(Fnr.of(fnr)).get().uuid
+        kandidatForUtmeldingRepository.lagreKandidat(ArbeidssøkerPeriodeAvsluttet(
+            aktorId = aktorId,
+            fnr = Fnr.of(fnr),
+            oppfolgingsperiodeUuid = oppfolgingsperiodeUuid,
+            avsluttetAv = KandidatForUtmeldingHendelseAvsluttetAv.VEILEDER,
+            kilde ="kilde",
+            aarsak = "aarsak")
+        )
+        assertThat(kandidatForUtmeldingRepository.hentKandidat(aktorId)).isNotNull()
+
+        val nyPeriode = arbeidssokerperiode(
+            fnr,
+            periodeStartet = LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant()
+        )
+        arbeidssoekerperiodeConsumerService.consumeArbeidssøkerperiode(
+            ConsumerRecord(
+                "topic",
+                0,
+                0,
+                "dummyKey",
+                nyPeriode
+            )
+        )
+
+        assertThat(kandidatForUtmeldingRepository.hentKandidat(aktorId)).isNull()
+    }
+
+    @Test
     fun `Sletter kandidat-for-utmelding når ny oppfølgingsperiode startes via melding fra Arena`() {
         mockVeilarbArenaOppfolgingsBruker(Fnr.of(fnr), Formidlingsgruppe.ISERV)
         startOppfolgingSomArbeidsoker(aktorId, Fnr.of(fnr))
@@ -211,6 +240,28 @@ class KandidatForUtmeldingFlytTest(
         val registrering = OppfolgingsRegistrering.arenaSyncOppfolgingBrukerRegistrering(Fnr.of(fnr), aktorId,
             Formidlingsgruppe.IARBS, Kvalifiseringsgruppe.VURDU, EnhetId("0318"))
         startOppfolging(aktorId, registrering)
+
+        assertThat(kandidatForUtmeldingRepository.hentKandidat(aktorId)).isNull()
+    }
+
+    @Test
+    fun `Sletter kandidat-for-utmelding når ny oppfølgingsperiode reaktiveres`() {
+        mockVeilarbArenaOppfolgingsBruker(Fnr.of(fnr), Formidlingsgruppe.ISERV)
+        startOppfolgingSomArbeidsoker(aktorId, Fnr.of(fnr))
+        mockInternBrukerAuthOk(UUID.randomUUID(), aktorId, Fnr.of(fnr))
+        mockArenaOppfolgingServiceRegistrerIkkeArbeidssoker(Fnr.of(fnr))
+        val oppfolgingsperiodeUuid = oppfolgingService.hentGjeldendeOppfolgingsperiode(Fnr.of(fnr)).get().uuid
+        kandidatForUtmeldingRepository.lagreKandidat(ArbeidssøkerPeriodeAvsluttet(
+            aktorId = aktorId,
+            fnr = Fnr.of(fnr),
+            oppfolgingsperiodeUuid = oppfolgingsperiodeUuid,
+            avsluttetAv = KandidatForUtmeldingHendelseAvsluttetAv.VEILEDER,
+            kilde ="kilde",
+            aarsak = "aarsak")
+        )
+        assertThat(kandidatForUtmeldingRepository.hentKandidat(aktorId)).isNotNull()
+
+        reaktiveringService.reaktiverBrukerIArena(Fnr.of(fnr))
 
         assertThat(kandidatForUtmeldingRepository.hentKandidat(aktorId)).isNull()
     }

--- a/src/test/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingRepositoryTest.kt
@@ -1,29 +1,25 @@
 package no.nav.veilarboppfolging.kandidatForUtmelding
 
+import java.util.UUID
 import no.nav.common.types.identer.AktorId
 import no.nav.common.types.identer.Fnr
 import no.nav.veilarboppfolging.LocalDatabaseSingleton
 import no.nav.veilarboppfolging.oppfolgingsbruker.BrukerRegistrant
 import no.nav.veilarboppfolging.oppfolgingsbruker.inngang.OppfolgingsRegistrering.Companion.arbeidssokerRegistrering
-import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.AvregistreringsType
 import no.nav.veilarboppfolging.repository.OppfolgingsPeriodeRepository
 import no.nav.veilarboppfolging.repository.OppfolgingsStatusRepository
-import no.nav.veilarboppfolging.repository.ReaktiveringRepository
-import no.nav.veilarboppfolging.service.ReaktiverOppfolgingDto
 import no.nav.veilarboppfolging.test.DbTestUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.transaction.support.TransactionTemplate
-import java.util.UUID
 
 class KandidatForUtmeldingRepositoryTest {
     private val jdbcTemplate = LocalDatabaseSingleton.jdbcTemplate
     private val namedJdbcTemplate = NamedParameterJdbcTemplate(jdbcTemplate)
     private val transactor: TransactionTemplate = DbTestUtils.createTransactor(jdbcTemplate)
     val oppfolgingsPeriodeRepository = OppfolgingsPeriodeRepository(jdbcTemplate, transactor)
-    val reaktiveringRepository = ReaktiveringRepository(namedJdbcTemplate)
     val kandidatForUtmeldingRepository = KandidatForUtmeldingRepository(namedJdbcTemplate)
     val oppfolgingsStatusRepository = OppfolgingsStatusRepository(NamedParameterJdbcTemplate(jdbcTemplate))
     val aktorId = AktorId.of("4321")
@@ -35,53 +31,11 @@ class KandidatForUtmeldingRepositoryTest {
     }
 
     @Test
-    fun `Henter ikke kandidat som har fått avsluttet oppfølgingsperioden`() {
+    fun `Henter kandidat`() {
         val oppfolgingsbruker = arbeidssokerRegistrering(fnr, aktorId, BrukerRegistrant(fnr))
         oppfolgingsStatusRepository.opprettOppfolging(aktorId)
         oppfolgingsPeriodeRepository.start(oppfolgingsbruker)
         val oppfolgingsperiodeUuid = oppfolgingsPeriodeRepository.hentOppfolgingsperioder(aktorId).first().uuid
-        kandidatForUtmeldingRepository.lagreKandidat(arbeidssøkerPeriodeAvsluttet(oppfolgingsperiodeUuid))
-        oppfolgingsPeriodeRepository.avsluttSistePeriodeOgAvsluttOppfolging(aktorId, "A1111111", "Fordi", AvregistreringsType.ManuellAvregistrering )
-
-        val kandidat = kandidatForUtmeldingRepository.hentKandidat(aktorId)
-
-        assertThat(kandidat).isNull()
-    }
-
-    @Test
-    fun `Henter kandidat som har gjeldende oppfølgingsperiode`() {
-        val oppfolgingsbruker = arbeidssokerRegistrering(fnr, aktorId, BrukerRegistrant(fnr))
-        oppfolgingsStatusRepository.opprettOppfolging(aktorId)
-        oppfolgingsPeriodeRepository.start(oppfolgingsbruker)
-        val oppfolgingsperiodeUuid = oppfolgingsPeriodeRepository.hentOppfolgingsperioder(aktorId).first().uuid
-        kandidatForUtmeldingRepository.lagreKandidat(arbeidssøkerPeriodeAvsluttet(oppfolgingsperiodeUuid))
-
-        val kandidat = kandidatForUtmeldingRepository.hentKandidat(aktorId)
-
-        assertThat(kandidat).isNotNull()
-    }
-
-    @Test
-    fun `Skal ikke hente ut kandidat som har blitt reaktivert`() {
-        val oppfolgingsbruker = arbeidssokerRegistrering(fnr, aktorId, BrukerRegistrant(fnr))
-        oppfolgingsStatusRepository.opprettOppfolging(aktorId)
-        oppfolgingsPeriodeRepository.start(oppfolgingsbruker)
-        val oppfolgingsperiodeUuid = oppfolgingsPeriodeRepository.hentOppfolgingsperioder(aktorId).first().uuid
-        kandidatForUtmeldingRepository.lagreKandidat(arbeidssøkerPeriodeAvsluttet(oppfolgingsperiodeUuid))
-        reaktiveringRepository.insertReaktivering(reaktiverOppfolging(oppfolgingsperiodeUuid))
-
-        val kandidat = kandidatForUtmeldingRepository.hentKandidat(aktorId)
-
-        assertThat(kandidat).isNull()
-    }
-
-    @Test
-    fun `Skal hente ut kandidat som har blitt reaktivert tidligere`() {
-        val oppfolgingsbruker = arbeidssokerRegistrering(fnr, aktorId, BrukerRegistrant(fnr))
-        oppfolgingsStatusRepository.opprettOppfolging(aktorId)
-        oppfolgingsPeriodeRepository.start(oppfolgingsbruker)
-        val oppfolgingsperiodeUuid = oppfolgingsPeriodeRepository.hentOppfolgingsperioder(aktorId).first().uuid
-        reaktiveringRepository.insertReaktivering(reaktiverOppfolging(oppfolgingsperiodeUuid))
         kandidatForUtmeldingRepository.lagreKandidat(arbeidssøkerPeriodeAvsluttet(oppfolgingsperiodeUuid))
 
         val kandidat = kandidatForUtmeldingRepository.hentKandidat(aktorId)
@@ -96,11 +50,5 @@ class KandidatForUtmeldingRepositoryTest {
         avsluttetAv = KandidatForUtmeldingHendelseAvsluttetAv.VEILEDER,
         aarsak = "årsak",
         kilde = "kilde"
-    )
-
-    fun reaktiverOppfolging(oppfolgingsperiodeUuid: UUID) = ReaktiverOppfolgingDto(
-        aktorId = aktorId,
-        oppfolgingsperiode = oppfolgingsperiodeUuid.toString(),
-        veilederIdent = "A111111"
     )
 }


### PR DESCRIPTION
Siden kandidater fjernes ved reaktivering og når bruker går ut av oppfølging skal det ikke lenger være nødvendig å joine med andre tabeller for å finne aktuelle kandidater. Jeg har også lagt til flere tester på disse scenariene. 

Jeg turte ikke å ta bort det at vi fjerner kandidater når oppfølgingen starter. Det føles som en trygghet at vi alltid gjør det.. 

https://trello.com/c/BmMC2Jmp/1662-endre-logikk-for-utmeldingskandidater-vi-har-lagret