### PR TITLE
Legg til forrige-periode-avsluttet på oppfolging-events metrikk

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ val logstashVersion = "9.0"
 val avroVersion = "1.12.1"
 val confluentKafkaAvroVersion = "8.2.0"
 val okHttpVersion = "5.4.0"
-val dabBigQuerySchemaVersion = "2026.05.11-16.10.4d6c1e3c3451"
+val dabBigQuerySchemaVersion = "2026.07.29-13.40.95c7d462f190"
 
 plugins {
     val kotlinVersion = "2.3.21"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ val logstashVersion = "9.0"
 val avroVersion = "1.12.1"
 val confluentKafkaAvroVersion = "8.2.0"
 val okHttpVersion = "5.4.0"
-val dabBigQuerySchemaVersion = "2026.07.30-12.21.600e6e95d9ce"
+val dabBigQuerySchemaVersion = "2026.07.30-14.56.9b2500dfe989"
 
 plugins {
     val kotlinVersion = "2.3.21"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ val logstashVersion = "9.0"
 val avroVersion = "1.12.1"
 val confluentKafkaAvroVersion = "8.2.0"
 val okHttpVersion = "5.4.0"
-val dabBigQuerySchemaVersion = "2026.07.29-13.40.95c7d462f190"
+val dabBigQuerySchemaVersion = "2026.07.30-12.21.600e6e95d9ce"
 
 plugins {
     val kotlinVersion = "2.3.21"

--- a/src/main/kotlin/no/nav/veilarboppfolging/controller/GraphqlExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/controller/GraphqlExceptionHandler.kt
@@ -49,7 +49,7 @@ class GraphqlExceptionHandler: DataFetcherExceptionResolver {
                 .errorType(ErrorType.ValidationError)
                 .build()
             is GraphqlError -> GraphqlErrorBuilder.newError(env)
-                .message(ex.toString())
+                .message(ex.message)
                 .errorType(ex.errorType)
                 .build()
             else -> GraphqlErrorBuilder.newError(env)

--- a/src/main/kotlin/no/nav/veilarboppfolging/eventsLogger/BigQueryClient.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/eventsLogger/BigQueryClient.kt
@@ -12,8 +12,6 @@ import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.ArbeidsøkerRegSync_Ikk
 import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.ArbeidsøkerRegSync_NoOp
 import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.ArbeidsøkerRegSync_OppdaterIservDato
 import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.Avregistrering
-import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.AvregistreringsType
-import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.ManuellAvregistrering
 import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.OppdateringFraArena_AlleredeUteAvOppfolging
 import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.OppdateringFraArena_BleIserv
 import no.nav.veilarboppfolging.oppfolgingsbruker.utgang.OppdateringFraArena_IkkeLengerIserv
@@ -37,7 +35,7 @@ data class UtmeldingsAntall(
 )
 
 interface BigQueryClient {
-    fun loggStartOppfolgingsperiode(startBegrunnelse: OppfolgingStartBegrunnelse, oppfolgingPeriodeId: UUID, startedAvType: StartetAvType, kvalifiseringsgruppe: Optional<Kvalifiseringsgruppe>, manuellSjekkLovligOpphold: Boolean? = null)
+    fun loggStartOppfolgingsperiode(startBegrunnelse: OppfolgingStartBegrunnelse, oppfolgingPeriodeId: UUID, startedAvType: StartetAvType, kvalifiseringsgruppe: Optional<Kvalifiseringsgruppe>, manuellSjekkLovligOpphold: Boolean? = null, forrigePeriodeAvsluttet: ZonedDateTime?)
     fun loggAvsluttOppfolgingsperiode(oppfolgingPeriodeId: UUID, avregistrering: Avregistrering, aktivIArena: Boolean? = null)
     fun loggUtmeldingsHendelse(utmelding: UtmeldingsHendelse)
     fun loggUtmeldingsCount(utmelding: UtmeldingsAntall)
@@ -80,7 +78,8 @@ class BigQueryClientImplementation(private val bigQuery: BigQuery): BigQueryClie
             oppfolgingPeriodeId: UUID,
             startedAvType: StartetAvType,
             kvalifiseringsgruppe: Optional<Kvalifiseringsgruppe>,
-            manuellSjekkLovligOpphold: Boolean?
+            manuellSjekkLovligOpphold: Boolean?,
+            forrigePeriodeAvsluttet: ZonedDateTime?
         ) {
         insertIntoOppfolgingEvents(oppfolgingsperiodeEventsTable) {
             mapOf(
@@ -90,6 +89,7 @@ class BigQueryClientImplementation(private val bigQuery: BigQuery): BigQueryClie
                 "timestamp" to ZonedDateTime.now().toOffsetDateTime().toString(),
                 "event" to BigQueryEventType.OPFOLGINGSPERIODE_START.name,
                 "kvalifiseringsgruppe" to kvalifiseringsgruppe.map { it.name }.orElse(null),
+                "forrigePeriodeAvsluttet" to forrigePeriodeAvsluttet?.toOffsetDateTime().toString(),
             ) + (if (manuellSjekkLovligOpphold != null) mapOf("manuellSjekkLovligOpphold" to manuellSjekkLovligOpphold) else emptyMap())
         }
     }

--- a/src/main/kotlin/no/nav/veilarboppfolging/service/OppfolgingService.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/service/OppfolgingService.kt
@@ -31,10 +31,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.util.Optional
-import java.util.concurrent.atomic.AtomicReference
-import java.util.function.Consumer
-import java.util.function.Function
-import java.util.stream.Collectors
 
 @Service
 class OppfolgingService @Autowired constructor(

--- a/src/main/kotlin/no/nav/veilarboppfolging/service/StartOppfolgingService.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/service/StartOppfolgingService.kt
@@ -39,9 +39,9 @@ open class StartOppfolgingService(
 ) {
     val log = LoggerFactory.getLogger(StartOppfolgingService::class.java)
 
-    fun startOppfolgingHvisIkkeAlleredeStartet(oppfolgingsbruker: OppfolgingsRegistrering) {
-        val aktorId = oppfolgingsbruker.aktorId
-        val fnr = oppfolgingsbruker.fnr
+    fun startOppfolgingHvisIkkeAlleredeStartet(oppfolgingsRegistrering: OppfolgingsRegistrering) {
+        val aktorId = oppfolgingsRegistrering.aktorId
+        val fnr = oppfolgingsRegistrering.fnr
         val kontaktinfo = manuellStatusService.hentDigdirKontaktinfo(fnr)
 
         transactor.executeWithoutResult { _ ->
@@ -66,16 +66,16 @@ open class StartOppfolgingService(
                 }
             }
 
-            oppfolgingsPeriodeRepository.start(oppfolgingsbruker)
+            oppfolgingsPeriodeRepository.start(oppfolgingsRegistrering)
 
             val perioder = oppfolgingsPeriodeRepository.hentOppfolgingsperioder(aktorId)
             val sistePeriode = OppfolgingsperiodeUtils.hentSisteOppfolgingsperiode(perioder)
-            val arbeidsoppfolgingskontor = when (oppfolgingsbruker) {
+            val arbeidsoppfolgingskontor = when (oppfolgingsRegistrering) {
                 is ManuellRegistreringVeileder -> {
-                    oppfolgingsbruker.kontorSattAvVeileder
+                    oppfolgingsRegistrering.kontorSattAvVeileder
                 }
                 is SystemRegistrering -> {
-                    oppfolgingsbruker.kontor
+                    oppfolgingsRegistrering.kontor
                 }
                 else -> {
                     null
@@ -89,11 +89,12 @@ open class StartOppfolgingService(
             publiserMinSideBeskjedHvisIkkeReservert(kontaktinfo, aktorId, fnr)
 
             bigQueryClient.loggStartOppfolgingsperiode(
-                oppfolgingsbruker.oppfolgingStartBegrunnelse,
+                oppfolgingsRegistrering.oppfolgingStartBegrunnelse,
                 sistePeriode.uuid,
-                oppfolgingsbruker.registrertAv.getType(),
-                Optional.ofNullable(getKvalifiseringsGruppe(oppfolgingsbruker)),
-                if (oppfolgingsbruker is ManuellRegistreringVeileder) oppfolgingsbruker.manueltSjekketLovligOpphold else null,
+                oppfolgingsRegistrering.registrertAv.getType(),
+                Optional.ofNullable(getKvalifiseringsGruppe(oppfolgingsRegistrering)),
+                if (oppfolgingsRegistrering is ManuellRegistreringVeileder) oppfolgingsRegistrering.manueltSjekketLovligOpphold else null,
+                perioder.mapNotNull { it.sluttDato }.maxByOrNull { it }
             )
         }
     }

--- a/src/main/resources/db/bigquery/V4__forrige_periode_avsluttet.sql
+++ b/src/main/resources/db/bigquery/V4__forrige_periode_avsluttet.sql
@@ -1,2 +1,2 @@
 ALTER TABLE oppfolging_metrikker.OPPFOLGINGSPERIODE_EVENTS
-ADD COLUMN forrigePeriodeAvsluttet TIMESTAMP default null;
+ADD COLUMN forrigePeriodeAvsluttet TIMESTAMP;

--- a/src/main/resources/db/bigquery/V4__forrige_periode_avsluttet.sql
+++ b/src/main/resources/db/bigquery/V4__forrige_periode_avsluttet.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oppfolging_metrikker.OPPFOLGINGSPERIODE_EVENTS
+ADD COLUMN forrigePeriodeAvsluttet TIMESTAMP default null;

--- a/src/test/kotlin/no/nav/veilarboppfolging/controller/GraphqlControllerTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/controller/GraphqlControllerTest.kt
@@ -164,7 +164,7 @@ class GraphqlControllerTest: IntegrationTest() {
         /* Query is hidden in test/resources/graphl-test :) */
         val result = tester.documentName("getEnhetQuery").variable("fnr", fnr.get()).execute()
         result.errors()
-            .expect { it.message.equals(expectedError.toString()) }
+            .expect { it.message.equals(expectedError.message) }
             .expect { it.errorType.equals(expectedError.errorType) }
             .verify()
     }


### PR DESCRIPTION
Legg til felt på oppfolging-startet event med når forrige periode var avsluttet. Skal brukes til å lage metrikker på om perioden ble feilaktig avsluttet, feks om det var under 24 timer siden forrige periode var avsluttet. Siden det er avslutningstidspunkt som legges til kan vi selv velge om vi skal se på perioder avsluttet innen 24 timer, 1 uke etc