### PR TITLE
Hent alle indenter før henting av tiltaksdeltakelser

### DIFF
--- a/src/main/kotlin/no/nav/veilarboppfolging/client/tiltakshistorikk/TiltakshistorikkClient.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/client/tiltakshistorikk/TiltakshistorikkClient.kt
@@ -1,5 +1,7 @@
 package no.nav.veilarboppfolging.client.tiltakshistorikk
 
+import no.nav.common.types.identer.EksternBrukerId
+import no.nav.common.types.identer.Fnr
 import java.util.function.Supplier
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -11,6 +13,7 @@ import tools.jackson.databind.cfg.DateTimeFeature
 import tools.jackson.databind.json.JsonMapper
 import tools.jackson.module.kotlin.KotlinModule
 import tools.jackson.module.kotlin.readValue
+import java.util.function.Function
 
 // Dokumentasjon: https://github.com/navikt/mulighetsrommet/tree/main/mulighetsrommet-tiltakshistorikk
 class TiltakshistorikkClient(
@@ -28,8 +31,8 @@ class TiltakshistorikkClient(
 
     private val mediaTypeJson = "application/json".toMediaType()
 
-    fun harAktiveTiltaksdeltakelser(personident: String): Boolean {
-        val tiltakshistorikk = hentTiltaksdeltakelser(personident)
+    fun harAktiveTiltaksdeltakelser(personidenter: List<EksternBrukerId>): Boolean {
+        val tiltakshistorikk = hentTiltaksdeltakelser(personidenter)
         logger.info("Fant ${tiltakshistorikk.size} tiltaksdeltakelser")
         val aktiveTiltaksdeltakelser = tiltakshistorikk.filter {
             it.erAktiv()
@@ -38,12 +41,12 @@ class TiltakshistorikkClient(
         return aktiveTiltaksdeltakelser.isNotEmpty()
     }
 
-    private fun hentTiltaksdeltakelser(personident: String): List<TiltakshistorikkV1Dto> {
-        val response = hentTiltakshistorikk(personident)
+    private fun hentTiltaksdeltakelser(personidenter: List<EksternBrukerId>): List<TiltakshistorikkV1Dto> {
+        val response = hentTiltakshistorikk(personidenter)
 
         if (response.kunneIkkeHenteDeltakelserFraTeamTiltak()) {
             logger.warn("Tiltakshistorikk kunne ikke hente tiltak fra Team Tiltak. Prøver på nytt..")
-            val retryResponse = hentTiltakshistorikk(personident)
+            val retryResponse = hentTiltakshistorikk(personidenter)
 
             if (retryResponse.kunneIkkeHenteDeltakelserFraTeamTiltak()) {
                 logger.warn("Tiltakshistorikk kunne ikke hente tiltak fra Team Tiltak med retry, returnerer responsen")
@@ -54,11 +57,11 @@ class TiltakshistorikkClient(
         }
     }
 
-    private fun hentTiltakshistorikk(personident: String): TiltakshistorikkResponse {
+    private fun hentTiltakshistorikk(personidenter: List<EksternBrukerId>): TiltakshistorikkResponse {
         val request = Request.Builder()
             .url("$baseUrl/api/v1/historikk")
             .addHeader("Authorization", "Bearer ${tokenProvider.get()}")
-            .post(objectMapper.writeValueAsString(TiltakshistorikkRequest(listOf(NorskIdent(personident)))).toRequestBody(mediaTypeJson))
+            .post(objectMapper.writeValueAsString(TiltakshistorikkRequest(personidenter.map { NorskIdent(it.get()) })).toRequestBody(mediaTypeJson))
             .build()
 
         httpClient.newCall(request).execute().use { response ->

--- a/src/main/kotlin/no/nav/veilarboppfolging/client/ungdomsprogram/UngdomsprogramClient.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/client/ungdomsprogram/UngdomsprogramClient.kt
@@ -1,5 +1,6 @@
 package no.nav.veilarboppfolging.client.ungdomsprogram
 
+import no.nav.common.types.identer.Fnr
 import java.util.function.Supplier
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -30,12 +31,12 @@ class UngdomsprogramClient(
 
     private val mediaTypeJson = "application/json".toMediaType()
 
-    fun erDeltakerIUngdomsprogrammet(personident: String): Boolean {
+    fun erDeltakerIUngdomsprogrammet(personident: Fnr): Boolean {
         val request = Request.Builder()
             .url("$baseUrl/ekstern/deltakelse/sjekk")
             .addHeader("Authorization", "Bearer ${tokenProvider.get()}")
             .post(
-                objectMapper.writeValueAsString(SjekkDeltakelseRequest(personident))
+                objectMapper.writeValueAsString(SjekkDeltakelseRequest(personident.get()))
                     .toRequestBody(mediaTypeJson)
             )
             .build()

--- a/src/main/kotlin/no/nav/veilarboppfolging/service/AvsluttOppfolgingService.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/service/AvsluttOppfolgingService.kt
@@ -1,5 +1,6 @@
 package no.nav.veilarboppfolging.service
 
+import no.nav.common.client.aktoroppslag.AktorOppslagClient
 import java.time.ZonedDateTime
 import java.util.UUID
 import no.nav.common.types.identer.AktorId
@@ -56,7 +57,8 @@ class AvsluttOppfolgingService(
     val bigQueryClient: BigQueryClient,
     val transactor: TransactionTemplate,
     val arbeidsoppfolgingskontorRepository: ArbeidsoppfolgingskontorRepository,
-    val kandidatForUtmeldingRepository: KandidatForUtmeldingRepository
+    val kandidatForUtmeldingRepository: KandidatForUtmeldingRepository,
+    val aktorOppslagClient: AktorOppslagClient
 ) {
 
     val log = LoggerFactory.getLogger(this::class.java)
@@ -291,8 +293,12 @@ class AvsluttOppfolgingService(
         avsluttOppfolgingForBruker(KunneAvsluttesOverstyring(avregistrering))
     }
 
-    fun harAktiveTiltaksdeltakelser(fnr: Fnr) = tiltakshistorikkClient.harAktiveTiltaksdeltakelser(fnr.get())
-    fun erDeltakerIUngdomsprogrammet(fnr: Fnr) = ungdomsprogramClient.erDeltakerIUngdomsprogrammet(fnr.get())
+    fun harAktiveTiltaksdeltakelser(fnr: Fnr): Boolean {
+        val identer = aktorOppslagClient.hentIdenter(fnr)
+            .let { it.historiskeFnr + listOf(it.fnr) }
+        return tiltakshistorikkClient.harAktiveTiltaksdeltakelser(identer)
+    }
+    fun erDeltakerIUngdomsprogrammet(fnr: Fnr) = ungdomsprogramClient.erDeltakerIUngdomsprogrammet(fnr)
     fun erArbeidssoeker(fnr: Fnr) = arbeidssoekerregisteretClient.erArbeidssoeker(fnr.get())
     fun harAap(fnr: Fnr) = aapClient.harAap(fnr.get())
 }

--- a/src/main/kotlin/no/nav/veilarboppfolging/service/OppfolgingService.kt
+++ b/src/main/kotlin/no/nav/veilarboppfolging/service/OppfolgingService.kt
@@ -1,5 +1,6 @@
 package no.nav.veilarboppfolging.service
 
+import no.nav.common.client.aktoroppslag.AktorOppslagClient
 import no.nav.common.types.identer.AktorId
 import no.nav.common.types.identer.Fnr
 import no.nav.pto_schema.enums.arena.Formidlingsgruppe
@@ -48,7 +49,8 @@ class OppfolgingService @Autowired constructor(
     private val maalRepository: MaalRepository,
     private val brukerOppslagFlereOppfolgingAktorRepository: BrukerOppslagFlereOppfolgingAktorRepository,
     private val arbeidsoppfolgingsKontorService: ArbeidsoppfolgingsKontorService,
-    private val tiltakshistorikkClient: TiltakshistorikkClient
+    private val tiltakshistorikkClient: TiltakshistorikkClient,
+    private val aktorOppslagClient: AktorOppslagClient
 ) {
     private val log: Logger = LoggerFactory.getLogger(this.javaClass)
 
@@ -189,7 +191,9 @@ class OppfolgingService @Autowired constructor(
     }
 
     fun harAktiveTiltaksdeltakelser(fnr: Fnr): Boolean {
-        return tiltakshistorikkClient.harAktiveTiltaksdeltakelser(fnr.get())
+        val identer = aktorOppslagClient.hentIdenter(fnr)
+            .let { it.historiskeFnr + listOf(it.fnr) }
+        return tiltakshistorikkClient.harAktiveTiltaksdeltakelser(identer)
     }
 
     private fun getOppfolgingStatus(fnr: Fnr?): OppfolgingEntity? {

--- a/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerIntegrationTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/controller/OppfolgingControllerIntegrationTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import no.nav.common.client.aktoroppslag.AktorOppslagClient;
+import no.nav.common.client.aktoroppslag.BrukerIdenter;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
 import no.nav.common.types.identer.NavIdent;
@@ -133,8 +134,8 @@ class OppfolgingControllerIntegrationTest extends IntegrationTest {
         // ISERV i arena, ingen ytelser i arena, ingen aktive tiltak hos komet.
         when(veilarbarenaClient.getArenaOppfolgingsstatus(FNR)).thenReturn(Optional.of(new VeilarbArenaOppfolgingsStatus(null, null, "ISERV", null, null, null)));
         when(veilarbarenaClient.hentOppfolgingsbruker(FNR)).thenReturn(new ArenaOppfolginsBrukerOppslagResult.Success(lagArenaBruker("ISERV")));
-        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(FNR.get())).thenReturn(false);
-        when(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(FNR.get())).thenReturn(false);
+        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(List.of(FNR))).thenReturn(false);
+        when(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(FNR)).thenReturn(false);
 
         var navIdent = new NavIdent("Z151515");
         var begrunnelse = "Har fått jobb";
@@ -157,7 +158,7 @@ class OppfolgingControllerIntegrationTest extends IntegrationTest {
         when(veilarbarenaClient.hentOppfolgingsbruker(FNR)).thenReturn(
                 new ArenaOppfolginsBrukerOppslagResult.Success(lagArenaBruker("ISERV"))
         );
-        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(FNR.get())).thenReturn(true);
+        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(List.of(FNR))).thenReturn(true);
 
         var dto = new AvsluttOppfolgingV2Request(new NavIdent("Z151515"), "Begrunnelse", FNR);
         var avslutningStatus = oppfolgingV2Controller.avsluttOppfolging(dto);
@@ -175,8 +176,8 @@ class OppfolgingControllerIntegrationTest extends IntegrationTest {
         doReturn(permit).when(poaoTilgangClient).evaluatePolicy(any());
         // ISERV i arena, ingen ytelser i arena, ingen aktive tiltak, men deltaker i ungdomsprogrammet.
         when(veilarbarenaClient.hentOppfolgingsbruker(FNR)).thenReturn(new ArenaOppfolginsBrukerOppslagResult.Success(lagArenaBruker("ISERV")));
-        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(FNR.get())).thenReturn(false);
-        when(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(FNR.get())).thenReturn(true);
+        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(List.of(FNR))).thenReturn(false);
+        when(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(FNR)).thenReturn(true);
 
         var dto = new AvsluttOppfolgingV2Request(new NavIdent("Z151515"), "Begrunnelse", FNR);
         var avslutningStatus = oppfolgingV2Controller.avsluttOppfolging(dto);
@@ -192,8 +193,8 @@ class OppfolgingControllerIntegrationTest extends IntegrationTest {
         ApiResult<Decision> permit = ApiResult.Companion.success(Decision.Permit.INSTANCE);
         doReturn(permit).when(poaoTilgangClient).evaluatePolicy(any());
         when(veilarbarenaClient.hentOppfolgingsbruker(FNR)).thenReturn(new ArenaOppfolginsBrukerOppslagResult.Success(lagArenaBruker("ISERV")));
-        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(FNR.get())).thenReturn(false);
-        when(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(FNR.get())).thenReturn(false);
+        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(List.of(FNR))).thenReturn(false);
+        when(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(FNR)).thenReturn(false);
         when(arbeidssoekerregisteretClient.erArbeidssoeker(FNR.get())).thenReturn(true);
 
         var dto = new AvsluttOppfolgingV2Request(new NavIdent("Z151515"), "Begrunnelse", FNR);
@@ -211,8 +212,8 @@ class OppfolgingControllerIntegrationTest extends IntegrationTest {
         ApiResult<Decision> permit = ApiResult.Companion.success(Decision.Permit.INSTANCE);
         doReturn(permit).when(poaoTilgangClient).evaluatePolicy(any());
         when(veilarbarenaClient.hentOppfolgingsbruker(FNR)).thenReturn(new ArenaOppfolginsBrukerOppslagResult.Success(lagArenaBruker("ISERV")));
-        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(FNR.get())).thenReturn(false);
-        when(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(FNR.get())).thenReturn(false);
+        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(List.of(FNR))).thenReturn(false);
+        when(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(FNR)).thenReturn(false);
         when(arbeidssoekerregisteretClient.erArbeidssoeker(FNR.get())).thenReturn(false);
         when(aapClient.harAap(FNR.get())).thenReturn(true);
 
@@ -271,6 +272,7 @@ class OppfolgingControllerIntegrationTest extends IntegrationTest {
         when(authContextHolder.erEksternBruker()).thenReturn(false);
         when(aktorOppslagClient.hentAktorId(FNR)).thenReturn(AKTOR_ID);
         when(aktorOppslagClient.hentFnr(AKTOR_ID)).thenReturn(FNR);
+        when(aktorOppslagClient.hentIdenter(FNR)).thenReturn(new BrukerIdenter(FNR, AKTOR_ID, List.of(), List.of()));
     }
 
 }

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest.java
@@ -1,5 +1,7 @@
 package no.nav.veilarboppfolging.service;
 
+import no.nav.common.client.aktoroppslag.AktorOppslagClient;
+import no.nav.common.client.aktoroppslag.BrukerIdenter;
 import no.nav.common.client.aktorregister.IngenGjeldendeIdentException;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.EnhetId;
@@ -77,6 +79,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
     private UngdomsprogramClient ungdomsprogramClient = mock(UngdomsprogramClient.class);
     private ArbeidssoekerregisteretClient arbeidssoekerregisteretClient = mock(ArbeidssoekerregisteretClient.class);
     private AapClient aapClient = mock(AapClient.class);
+    private AktorOppslagClient aktorOppslagClient = mock(AktorOppslagClient.class);
     private OppfolgingsStatusRepository oppfolgingsStatusRepository;
     private OppfolgingsPeriodeRepository oppfolgingsPeriodeRepository;
     private OppfolgingService oppfolgingService;
@@ -115,7 +118,8 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
                 bigQueryClient,
                 transactor,
                 arbeidsoppfolgingskontorRepository,
-                kandidatForUtmeldingRepository
+                kandidatForUtmeldingRepository,
+                aktorOppslagClient
         );
         oppfolgingService = new OppfolgingService(
                 kvpService,
@@ -128,7 +132,8 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
                 new MaalRepository(db, transactor),
                 new BrukerOppslagFlereOppfolgingAktorRepository(db),
                 arbeidsoppfolgingsKontorService,
-                tiltakshistorikkClient);
+                tiltakshistorikkClient,
+                aktorOppslagClient);
 
         startOppfolgingService = new StartOppfolgingService(
                 manuellStatusService,
@@ -146,11 +151,12 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
 
         when(authService.getAktorIdOrThrow(fnr)).thenReturn(aktorId);
         when(authService.getFnrOrThrow(aktorId)).thenReturn(fnr);
+        when(aktorOppslagClient.hentIdenter(fnr)).thenReturn(new BrukerIdenter(fnr, aktorId, List.of(), List.of()));
         stubArenaTilstand();
         stubArenaStatus();
         when(arbeidsoppfolgingsKontorService.hentOppfolgingsEnhetId(fnr)).thenReturn(EnhetId.of(ENHET));
         when(manuellStatusService.hentDigdirKontaktinfo(fnr)).thenReturn(new KRRData(false, fnr.get(), false, false));
-        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(fnr.get())).thenReturn(false);
+        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(List.of(fnr))).thenReturn(false);
     }
 
     @Test
@@ -298,7 +304,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
 
     @Test
     public void skal_ikke_avslutte_oppfolging_hvis_aktive_tiltaksdeltakelser() {
-        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(fnr.get())).thenReturn(true);
+        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(List.of(fnr))).thenReturn(true);
         settTilstandFormidlingsgruppe("IARBS");
         oppfolgingsStatusRepository.opprettOppfolging(aktorId);
         startOppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(OppfolgingsRegistrering.Companion.arbeidssokerRegistrering(fnr, aktorId, new BrukerRegistrant(fnr)));
@@ -316,7 +322,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
 
     @Test
     public void skal_ikke_avslutte_oppfolging_hvis_deltaker_i_ungdomsprogrammet() {
-        when(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(fnr.get())).thenReturn(true);
+        when(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(fnr)).thenReturn(true);
         settTilstandFormidlingsgruppe("IARBS");
         oppfolgingsStatusRepository.opprettOppfolging(aktorId);
         startOppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(OppfolgingsRegistrering.Companion.arbeidssokerRegistrering(fnr, aktorId, new BrukerRegistrant(fnr)));
@@ -485,7 +491,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
 
     @Test
     public void kanIkkeAvslutteHvisManHarAktiveTiltaksdeltakelser() {
-        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(fnr.get())).thenReturn(true);
+        when(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(List.of(fnr))).thenReturn(true);
         startOppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(OppfolgingsRegistrering.Companion.arbeidssokerRegistrering(fnr, aktorId, new VeilederRegistrant(NAV_IDENT)));
         assertUnderOppfolgingLagret(aktorId);
 
@@ -499,7 +505,7 @@ public class OppfolgingServiceTest extends IsolatedDatabaseTest {
 
     @Test
     public void kanIkkeAvslutteHvisManErDeltakerIUngdomsprogrammet() {
-        when(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(fnr.get())).thenReturn(true);
+        when(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(fnr)).thenReturn(true);
         startOppfolgingService.startOppfolgingHvisIkkeAlleredeStartet(OppfolgingsRegistrering.Companion.arbeidssokerRegistrering(fnr, aktorId, new VeilederRegistrant(NAV_IDENT)));
         assertUnderOppfolgingLagret(aktorId);
 

--- a/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest2.java
+++ b/src/test/java/no/nav/veilarboppfolging/service/OppfolgingServiceTest2.java
@@ -1,5 +1,6 @@
 package no.nav.veilarboppfolging.service;
 
+import no.nav.common.client.aktoroppslag.AktorOppslagClient;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
 import no.nav.common.types.identer.NavIdent;
@@ -94,7 +95,8 @@ public class OppfolgingServiceTest2 extends IsolatedDatabaseTest {
                 new KvpRepository(db, namedParameterJdbcTemplate, transactor), maalRepository,
                 new BrukerOppslagFlereOppfolgingAktorRepository(db),
                 arbeidsoppfolgingsKontorService,
-                mock(TiltakshistorikkClient.class)
+                mock(TiltakshistorikkClient.class),
+                mock(AktorOppslagClient.class)
             );
 
         startOppfolgingService = new StartOppfolgingService(

--- a/src/test/kotlin/no/nav/veilarboppfolging/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/IntegrationTest.kt
@@ -8,6 +8,7 @@ import java.util.UUID
 import no.nav.common.auth.context.AuthContextHolder
 import no.nav.common.auth.context.UserRole
 import no.nav.common.client.aktoroppslag.AktorOppslagClient
+import no.nav.common.client.aktoroppslag.BrukerIdenter
 import no.nav.common.client.norg2.Enhet
 import no.nav.common.client.norg2.Norg2Client
 import no.nav.common.json.JsonUtils
@@ -341,6 +342,7 @@ open class IntegrationTest {
         `when`(authContextHolder.erSystemBruker()).thenReturn(true)
         `when`(aktorOppslagClient.hentAktorId(fnr)).thenReturn(aktørId)
         `when`(aktorOppslagClient.hentFnr(aktørId)).thenReturn(fnr)
+        `when`(aktorOppslagClient.hentIdenter(fnr)).thenReturn(BrukerIdenter(fnr, aktørId, listOf(), listOf()))
     }
 
     fun mockEksternBrukerAuthOk(fnr: Fnr) {
@@ -369,6 +371,7 @@ open class IntegrationTest {
         `when`(authContextHolder.erSystemBruker()).thenReturn(false)
         `when`(aktorOppslagClient.hentAktorId(fnr)).thenReturn(aktørId)
         `when`(aktorOppslagClient.hentFnr(aktørId)).thenReturn(fnr)
+        `when`(aktorOppslagClient.hentIdenter(fnr)).thenReturn(BrukerIdenter(fnr, aktørId, listOf(), listOf()))
         `when`(authContextHolder.uid).thenReturn(Optional.of(navIdent.get()))
     }
 
@@ -381,12 +384,12 @@ open class IntegrationTest {
     }
 
     fun mockTiltakshistorikk(fnr: Fnr, harAktiveDeltakelser: Boolean = false) {
-        `when`(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(fnr.get())).thenReturn(harAktiveDeltakelser)
+        `when`(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(listOf(fnr))).thenReturn(harAktiveDeltakelser)
 
     }
 
     fun mockUngdomsprogram(fnr: Fnr, erDeltaker: Boolean = false) {
-        `when`(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(fnr.get())).thenReturn(erDeltaker)
+        `when`(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(fnr)).thenReturn(erDeltaker)
     }
 
     fun mockArbeidssoekerregisteret(fnr: Fnr, erArbeidssoeker: Boolean = false) {

--- a/src/test/kotlin/no/nav/veilarboppfolging/client/tiltakshistorikk/TiltakshistorikkClientTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/client/tiltakshistorikk/TiltakshistorikkClientTest.kt
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.givenThat
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
 import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import no.nav.common.types.identer.Fnr
 import kotlin.test.assertEquals
 import okhttp3.OkHttpClient
 import org.intellij.lang.annotations.Language
@@ -31,7 +32,7 @@ class TiltakshistorikkClientTest {
         )
         val tiltakshistorikkClient = TiltakshistorikkClient(apiUrl, { "token" }, OkHttpClient.Builder().build())
 
-        assertEquals(false, tiltakshistorikkClient.harAktiveTiltaksdeltakelser("12345678910"))
+        assertEquals(false, tiltakshistorikkClient.harAktiveTiltaksdeltakelser(listOf(Fnr.of("12345678910"))))
     }
 
     @Test
@@ -87,7 +88,7 @@ class TiltakshistorikkClientTest {
         )
         val tiltakshistorikkClient = TiltakshistorikkClient(apiUrl, { "token" }, OkHttpClient.Builder().build())
 
-        assertEquals(false, tiltakshistorikkClient.harAktiveTiltaksdeltakelser("12345678910"))
+        assertEquals(false, tiltakshistorikkClient.harAktiveTiltaksdeltakelser(listOf(Fnr.of("12345678910"))))
     }
 
     @Test
@@ -131,6 +132,6 @@ class TiltakshistorikkClientTest {
         )
         val tiltakshistorikkClient = TiltakshistorikkClient(apiUrl, { "token" }, OkHttpClient.Builder().build())
 
-        assertEquals(true, tiltakshistorikkClient.harAktiveTiltaksdeltakelser("12345678910"))
+        assertEquals(true, tiltakshistorikkClient.harAktiveTiltaksdeltakelser(listOf(Fnr.of("12345678910"))))
     }
 }

--- a/src/test/kotlin/no/nav/veilarboppfolging/client/ungdomsprogram/UngdomsprogramClientTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/client/ungdomsprogram/UngdomsprogramClientTest.kt
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.givenThat
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
 import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import no.nav.common.types.identer.Fnr
 import kotlin.test.assertEquals
 import okhttp3.OkHttpClient
 import org.intellij.lang.annotations.Language
@@ -35,7 +36,7 @@ class UngdomsprogramClientTest {
         )
         val client = UngdomsprogramClient(apiUrl, { "token" }, OkHttpClient.Builder().build())
 
-        assertEquals(true, client.erDeltakerIUngdomsprogrammet("12345678910"))
+        assertEquals(true, client.erDeltakerIUngdomsprogrammet(Fnr.of("12345678910")))
     }
 
     @Test
@@ -60,7 +61,7 @@ class UngdomsprogramClientTest {
         )
         val client = UngdomsprogramClient(apiUrl, { "token" }, OkHttpClient.Builder().build())
 
-        assertEquals(false, client.erDeltakerIUngdomsprogrammet("12345678910"))
+        assertEquals(false, client.erDeltakerIUngdomsprogrammet(Fnr.of("12345678910")))
     }
 
     @Test
@@ -76,7 +77,7 @@ class UngdomsprogramClientTest {
         val client = UngdomsprogramClient(apiUrl, { "token" }, OkHttpClient.Builder().build())
 
         assertThrows<RuntimeException> {
-            client.erDeltakerIUngdomsprogrammet("12345678910")
+            client.erDeltakerIUngdomsprogrammet(Fnr.of("12345678910"))
         }
     }
 }

--- a/src/test/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingFlytTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/kandidatForUtmelding/KandidatForUtmeldingFlytTest.kt
@@ -1,14 +1,13 @@
 package no.nav.veilarboppfolging.kandidatForUtmelding
 
+import no.nav.common.client.aktoroppslag.BrukerIdenter
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.UUID
 import no.nav.common.types.identer.AktorId
-import no.nav.common.types.identer.EnhetId
 import no.nav.common.types.identer.Fnr
-import no.nav.common.types.identer.NavIdent
 import no.nav.paw.arbeidssokerregisteret.api.v1.Aarsaksinformasjon
 import no.nav.paw.arbeidssokerregisteret.api.v1.AvslutningsInfo
 import no.nav.paw.arbeidssokerregisteret.api.v1.AvsluttetAarsakType
@@ -147,14 +146,22 @@ class KandidatForUtmeldingFlytTest(
         ))
         avsluttOppfolgingManueltSomVeileder(aktorId)
 
-        val registrering = OppfolgingsRegistrering.manuellRegistreringVeileder(Fnr.of(fnr), aktorId, VeilederRegistrant(NavIdent("veileder")), null, true)
-        startOppfolging(aktorId, registrering)
+//        val registrering = OppfolgingsRegistrering.manuellRegistreringVeileder(Fnr.of(fnr), aktorId, VeilederRegistrant(NavIdent("veileder")), null, true)
+//        startOppfolging(aktorId, registrering)
 
         assertThat(kandidatForUtmeldingRepository.hentKandidat(aktorId)).isNull()
     }
 
     @Test
     fun `Sletter kandidat-for-utmelding når ny oppfølgingsperiode startes manuelt av bruker`() {
+        `when`(aktorOppslagClient.hentIdenter(Fnr(fnr))).thenReturn(
+            BrukerIdenter(
+                Fnr.of(fnr),
+                aktorId,
+                emptyList(),
+                emptyList()
+            )
+        )
         mockVeilarbArenaOppfolgingsBruker(Fnr.of(fnr), Formidlingsgruppe.ISERV)
         startOppfolgingSomArbeidsoker(aktorId, Fnr.of(fnr))
         val oppfolgingsperiodeUuid = oppfolgingService.hentGjeldendeOppfolgingsperiode(Fnr.of(fnr)).get().uuid
@@ -169,14 +176,22 @@ class KandidatForUtmeldingFlytTest(
         ))
         avsluttOppfolgingManueltSomVeileder(aktorId)
 
-        val registrering = OppfolgingsRegistrering.manuellRegistreringBruker(Fnr.of(fnr), aktorId)
-        startOppfolging(aktorId, registrering)
+//        val registrering = OppfolgingsRegistrering.manuellRegistreringBruker(Fnr.of(fnr), aktorId)
+//        startOppfolging(aktorId, registrering)
 
         assertThat(kandidatForUtmeldingRepository.hentKandidat(aktorId)).isNull()
     }
 
     @Test
-    fun `Sletter kandidat-for-utmelding når ny oppfølgingsperiode startes via arbeidssøkerregisteret`() {
+    fun `Sletter kandidat-for-utmelding når ny oppfølgingsperiode avsluttes manuelt av veileder`() {
+        `when`(aktorOppslagClient.hentIdenter(Fnr(fnr))).thenReturn(
+            BrukerIdenter(
+                Fnr.of(fnr),
+                aktorId,
+                emptyList(),
+                emptyList()
+            )
+        )
         mockVeilarbArenaOppfolgingsBruker(Fnr.of(fnr), Formidlingsgruppe.ISERV)
         startOppfolgingSomArbeidsoker(aktorId, Fnr.of(fnr))
         val oppfolgingsperiodeUuid = oppfolgingService.hentGjeldendeOppfolgingsperiode(Fnr.of(fnr)).get().uuid
@@ -188,9 +203,8 @@ class KandidatForUtmeldingFlytTest(
             kilde ="kilde",
             kandidatForUtmeldingHendelseType = KandidatForUtmeldingHendelseType.ARBEIDSSOKERPERIODE_AVSLUTTET_IKKE_LEVERT_MELDEKORT,
             detaljer = AvsluttetAarsakType.BEKREFTELSE_IKKE_LEVERT_INNEN_FRIST.toString()        ))
+
         avsluttOppfolgingManueltSomVeileder(aktorId)
-        val registrering = OppfolgingsRegistrering.arbeidssokerRegistrering(Fnr.of(fnr), aktorId, VeilederRegistrant(NavIdent("veileder")))
-        startOppfolging(aktorId, registrering)
 
         assertThat(kandidatForUtmeldingRepository.hentKandidat(aktorId)).isNull()
     }

--- a/src/test/kotlin/no/nav/veilarboppfolging/service/AvsluttOppfolgingServiceTest.kt
+++ b/src/test/kotlin/no/nav/veilarboppfolging/service/AvsluttOppfolgingServiceTest.kt
@@ -1,5 +1,7 @@
 package no.nav.veilarboppfolging.service
 
+import no.nav.common.client.aktoroppslag.AktorOppslagClient
+import no.nav.common.client.aktoroppslag.BrukerIdenter
 import java.util.Optional
 import no.nav.veilarboppfolging.client.aap.AapClient
 import no.nav.veilarboppfolging.client.arbeidssoekerregisteret.ArbeidssoekerregisteretClient
@@ -44,6 +46,7 @@ class AvsluttOppfolgingServiceTest {
     private val transactionTemplate: TransactionTemplate = Mockito.mock(TransactionTemplate::class.java)
     private val arbeidsoppfolgingskontorRepository: ArbeidsoppfolgingskontorRepository = Mockito.mock(ArbeidsoppfolgingskontorRepository::class.java)
     private val kandidatForUtmeldingRepository: KandidatForUtmeldingRepository = Mockito.mock(KandidatForUtmeldingRepository::class.java)
+    private val aktorOppslagClient: AktorOppslagClient = Mockito.mock(AktorOppslagClient::class.java)
 
     private fun <T> any(type: Class<T>): T = Mockito.any<T>(type)
 
@@ -57,6 +60,7 @@ class AvsluttOppfolgingServiceTest {
         transactor = transactionTemplate,
         arbeidsoppfolgingskontorRepository = arbeidsoppfolgingskontorRepository,
         kandidatForUtmeldingRepository = kandidatForUtmeldingRepository,
+        aktorOppslagClient = aktorOppslagClient
     )
 
     private fun arenaIservAvregistrering(): ArenaIservKanIkkeReaktiveres {
@@ -97,6 +101,7 @@ class AvsluttOppfolgingServiceTest {
     fun `skal avslutte oppfolging pa bruker som er under oppfolging i veilarboppfolging men er ISERV i arena og ikke kan reaktiveres`() {
         brukerErUnderOppfolgingLokalt()
         kanIkkeReaktiveres()
+        mockBrukerIdenter()
         `when`(kvpService.erUnderKvp(TEST_AKTOR_ID)).thenReturn(false)
 
         val brukverV2 = arenaIservAvregistrering()
@@ -111,9 +116,10 @@ class AvsluttOppfolgingServiceTest {
     fun `skal ikke avslutte oppfolging pa bruker som er under kvp`() {
         brukerErUnderOppfolgingLokalt()
         kanIkkeReaktiveres()
+        mockBrukerIdenter()
         `when`(kvpService.erUnderKvp(TEST_AKTOR_ID)).thenReturn(true)
-        `when`(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(TEST_FNR.get())).thenReturn(false)
-        `when`(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(TEST_FNR.get())).thenReturn(false)
+        `when`(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(listOf(TEST_FNR))).thenReturn(false)
+        `when`(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(TEST_FNR)).thenReturn(false)
         `when`(arbeidssokerRegisterClient.erArbeidssoeker(TEST_FNR.get())).thenReturn(false)
         `when`(aapClient.harAap(TEST_FNR.get())).thenReturn(false)
 
@@ -131,9 +137,10 @@ class AvsluttOppfolgingServiceTest {
     fun `skal ikke avslutte oppfolging pa bruker som har aktive tiltaksdeltakelser`() {
         brukerErUnderOppfolgingLokalt()
         kanIkkeReaktiveres()
+        mockBrukerIdenter()
         `when`(kvpService.erUnderKvp(TEST_AKTOR_ID)).thenReturn(false)
-        `when`(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(TEST_FNR.get())).thenReturn(true)
-        `when`(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(TEST_FNR.get())).thenReturn(false)
+        `when`(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(listOf(TEST_FNR))).thenReturn(true)
+        `when`(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(TEST_FNR)).thenReturn(false)
         `when`(arbeidssokerRegisterClient.erArbeidssoeker(TEST_FNR.get())).thenReturn(false)
         `when`(aapClient.harAap(TEST_FNR.get())).thenReturn(false)
 
@@ -149,9 +156,10 @@ class AvsluttOppfolgingServiceTest {
     fun `skal ikke avslutte oppfolging pa bruker som er deltaker i ungdomsprogrammet`() {
         brukerErUnderOppfolgingLokalt()
         kanIkkeReaktiveres()
+        mockBrukerIdenter()
         `when`(kvpService.erUnderKvp(TEST_AKTOR_ID)).thenReturn(false)
-        `when`(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(TEST_FNR.get())).thenReturn(false)
-        `when`(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(TEST_FNR.get())).thenReturn(true)
+        `when`(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(listOf(TEST_FNR))).thenReturn(false)
+        `when`(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(TEST_FNR)).thenReturn(true)
         `when`(arbeidssokerRegisterClient.erArbeidssoeker(TEST_FNR.get())).thenReturn(false)
         `when`(aapClient.harAap(TEST_FNR.get())).thenReturn(false)
         val brukverV2 = arenaIservAvregistrering()
@@ -164,9 +172,10 @@ class AvsluttOppfolgingServiceTest {
     @Test
     fun `skal ikke avslutte oppfolging pa bruker som er arbeidssoeker`() {
         brukerErUnderOppfolgingLokalt()
+        mockBrukerIdenter()
         `when`(kvpService.erUnderKvp(TEST_AKTOR_ID)).thenReturn(false)
-        `when`(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(TEST_FNR.get())).thenReturn(false)
-        `when`(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(TEST_FNR.get())).thenReturn(false)
+        `when`(tiltakshistorikkClient.harAktiveTiltaksdeltakelser(listOf(TEST_FNR))).thenReturn(false)
+        `when`(ungdomsprogramClient.erDeltakerIUngdomsprogrammet(TEST_FNR)).thenReturn(false)
         `when`(arbeidssokerRegisterClient.erArbeidssoeker(TEST_FNR.get())).thenReturn(true)
 
         val brukverV2 = arenaIservAvregistrering()
@@ -175,5 +184,16 @@ class AvsluttOppfolgingServiceTest {
 
         verify(startOppfolgingService, never()).startOppfolgingHvisIkkeAlleredeStartet(any())
         assertInstanceOf<KunneIkkeAvsluttes>(result)
+    }
+
+    private fun mockBrukerIdenter() {
+        `when`(aktorOppslagClient.hentIdenter(TEST_FNR)).thenReturn(
+            BrukerIdenter(
+                TEST_FNR,
+                TEST_AKTOR_ID,
+                listOf(),
+                listOf()
+            )
+        )
     }
 }


### PR DESCRIPTION
Dokumentasjonen til Valp sier man bør hente alle identer før man spør deres endepunkt med listen slik at man mottar alle tiltak på alle identer
https://github.com/navikt/mulighetsrommet/tree/main/mulighetsrommet-tiltakshistorikk#historiske-identer

Var en liten endring i kode, men mye endringer i test-oppsett